### PR TITLE
Avoid double llava registration

### DIFF
--- a/generate_text.py
+++ b/generate_text.py
@@ -22,14 +22,8 @@ import math
 
 questions = ["Can you describe the main features visible in this histopathology image?"]
 
-image_folder = "test_images_sup"
-answers_dir = [f"{image_folder}_answers/main"]
-
 ckpt = "wisdomik/Quilt-Llava-v1.5-7b"
 temp, conv_mode = 0, "vicuna_v1"
-
-for a in answers_dir:
-    if not os.path.exists(a): os.makedirs(a) 
 
 def split_list(lst, n):
     """Split a list into n (roughly) equal-sized chunks"""
@@ -46,15 +40,18 @@ def eval_model(args):
     args.model_path = ckpt
     args.temperature = temp
     args.conv_mode = conv_mode
-    
+
+    for a in args.answers_dir:
+        os.makedirs(a, exist_ok=True)
+
     # Model
     disable_torch_init()
     model_path = os.path.expanduser(args.model_path)
     model_name = get_model_name_from_path(model_path)
     tokenizer, model, image_processor, context_len = load_pretrained_model(model_path, args.model_base, model_name)
 
-    
-    for qs, ans_dir in zip(questions, answers_dir):
+
+    for qs, ans_dir in zip(questions, args.answers_dir):
         cur_prompt = qs
         if model.config.mm_use_im_start_end:
             qs = DEFAULT_IM_START_TOKEN + DEFAULT_IMAGE_TOKEN + DEFAULT_IM_END_TOKEN + '\n' + qs
@@ -68,7 +65,7 @@ def eval_model(args):
 
         input_ids = tokenizer_image_token(prompt, tokenizer, IMAGE_TOKEN_INDEX, return_tensors='pt').unsqueeze(0).cuda()
 
-        for image_path in [f"{image_folder}/{a}" for a in os.listdir(image_folder)]:
+        for image_path in [f"{args.image_folder}/{a}" for a in os.listdir(args.image_folder)]:
             image = Image.open(image_path)
             image_tensor = image_processor.preprocess(image, return_tensors='pt')['pixel_values'][0]
 
@@ -110,3 +107,14 @@ def eval_model(args):
             ans_file.close()
     
     print('Done')
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("image_folder", nargs="?", default="test_images_sup", help="folder containing images to describe")
+    parser.add_argument("--model-base", type=str, default=None)
+    parser.add_argument("--top-p", type=float, default=0.9)
+    parser.add_argument("--num-beams", type=int, default=1)
+    args = parser.parse_args()
+    args.answers_dir = [f"{args.image_folder}_answers/main"]
+    eval_model(args)

--- a/generate_text.py
+++ b/generate_text.py
@@ -40,7 +40,11 @@ def eval_model(args):
     if getattr(args, "temperature", None) is None:
         args.temperature = 0
     if getattr(args, "conv_mode", None) is None:
-        args.conv_mode = "vicuna_v1"
+        # LLaVA models such as Quilt-Llava expect the "llava_v1" conversation
+        # template. Using an incompatible template can lead to degenerate
+        # generations that ignore the visual input. Default to "llava_v1" so
+        # the model processes images properly unless the caller overrides it.
+        args.conv_mode = "llava_v1"
 
     for a in args.answers_dir:
         os.makedirs(a, exist_ok=True)
@@ -116,7 +120,7 @@ if __name__ == "__main__":
     parser.add_argument("--model-path", type=str, help="pretrained model checkpoint to use")
     parser.add_argument("--model-base", type=str, default=None)
     parser.add_argument("--temperature", type=float, default=0)
-    parser.add_argument("--conv-mode", type=str, default="vicuna_v1")
+    parser.add_argument("--conv-mode", type=str, default="llava_v1")
     parser.add_argument("--top-p", type=float, default=0.9)
     parser.add_argument("--num-beams", type=int, default=1)
     args = parser.parse_args()

--- a/generate_text.py
+++ b/generate_text.py
@@ -22,9 +22,6 @@ import math
 
 questions = ["Can you describe the main features visible in this histopathology image?"]
 
-ckpt = "wisdomik/Quilt-Llava-v1.5-7b"
-temp, conv_mode = 0, "vicuna_v1"
-
 def split_list(lst, n):
     """Split a list into n (roughly) equal-sized chunks"""
     chunk_size = math.ceil(len(lst) / n)  # integer division
@@ -37,9 +34,13 @@ def get_chunk(lst, n, k):
 
 
 def eval_model(args):
-    args.model_path = ckpt
-    args.temperature = temp
-    args.conv_mode = conv_mode
+    # configure defaults for model path, temperature, and conversation mode
+    if getattr(args, "model_path", None) is None:
+        args.model_path = "wisdomik/Quilt-Llava-v1.5-7b"
+    if getattr(args, "temperature", None) is None:
+        args.temperature = 0
+    if getattr(args, "conv_mode", None) is None:
+        args.conv_mode = "vicuna_v1"
 
     for a in args.answers_dir:
         os.makedirs(a, exist_ok=True)
@@ -112,7 +113,10 @@ def eval_model(args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("image_folder", nargs="?", default="test_images_sup", help="folder containing images to describe")
+    parser.add_argument("--model-path", type=str, help="pretrained model checkpoint to use")
     parser.add_argument("--model-base", type=str, default=None)
+    parser.add_argument("--temperature", type=float, default=0)
+    parser.add_argument("--conv-mode", type=str, default="vicuna_v1")
     parser.add_argument("--top-p", type=float, default=0.9)
     parser.add_argument("--num-beams", type=int, default=1)
     args = parser.parse_args()

--- a/llava/model/language_model/llava_llama.py
+++ b/llava/model/language_model/llava_llama.py
@@ -136,5 +136,8 @@ class LlavaLlamaForCausalLM(LlamaForCausalLM, LlavaMetaForCausalLM):
         )
         return model_inputs
 
-AutoConfig.register("llava", LlavaConfig)
-AutoModelForCausalLM.register(LlavaConfig, LlavaLlamaForCausalLM)
+try:
+    AutoConfig.register("llava", LlavaConfig)
+    AutoModelForCausalLM.register(LlavaConfig, LlavaLlamaForCausalLM)
+except ValueError:
+    pass

--- a/llava/model/language_model/llava_llama.py
+++ b/llava/model/language_model/llava_llama.py
@@ -131,7 +131,10 @@ class LlavaLlamaForCausalLM(LlamaForCausalLM, LlavaMetaForCausalLM):
                 "past_key_values": past_key_values,
                 "use_cache": kwargs.get("use_cache"),
                 "attention_mask": attention_mask,
-                "images": kwargs.get("images", None),
+                # Only pass images during the first generation step to avoid
+                # re-encoding them on subsequent calls when past_key_values is
+                # already populated.
+                "images": None if past_key_values is not None else kwargs.get("images", None),
             }
         )
         return model_inputs

--- a/llava/model/language_model/mpt/hf_prefixlm_converter.py
+++ b/llava/model/language_model/mpt/hf_prefixlm_converter.py
@@ -21,7 +21,12 @@ from transformers.models.bloom.modeling_bloom import (
 try:
     from transformers.models.bloom.modeling_bloom import _expand_mask as _expand_mask_bloom
 except ImportError:  # pragma: no cover - fallback for newer Transformers
-    from transformers.modeling_utils import expand_mask as _expand_mask_bloom
+    try:
+        from transformers.modeling_utils import expand_mask as _expand_mask_bloom
+    except Exception:  # pragma: no cover - fallback for latest Transformers
+        from transformers.modeling_attn_mask_utils import (
+            expand_mask as _expand_mask_bloom,
+        )
 from transformers.models.bloom.modeling_bloom import _make_causal_mask as _make_causal_mask_bloom
 from transformers.models.bloom.modeling_bloom import logging
 from transformers.models.gpt2.modeling_gpt2 import GPT2LMHeadModel
@@ -32,7 +37,12 @@ from transformers.models.opt.modeling_opt import OPTForCausalLM
 try:
     from transformers.models.opt.modeling_opt import _expand_mask as _expand_mask_opt
 except ImportError:  # pragma: no cover - fallback for newer Transformers
-    from transformers.modeling_utils import expand_mask as _expand_mask_opt
+    try:
+        from transformers.modeling_utils import expand_mask as _expand_mask_opt
+    except Exception:  # pragma: no cover - fallback for latest Transformers
+        from transformers.modeling_attn_mask_utils import (
+            expand_mask as _expand_mask_opt,
+        )
 from transformers.models.opt.modeling_opt import _make_causal_mask as _make_causal_mask_opt
 logger = logging.get_logger(__name__)
 _SUPPORTED_GPT_MODELS = (GPT2LMHeadModel, GPTJForCausalLM, GPTNeoForCausalLM, GPTNeoXForCausalLM)

--- a/llava/model/language_model/mpt/hf_prefixlm_converter.py
+++ b/llava/model/language_model/mpt/hf_prefixlm_converter.py
@@ -43,7 +43,28 @@ except Exception:  # pragma: no cover - bloom helper moved or removed
                 expanded = expanded.expand(mask.size(0), 1, tgt_length, src_len)
                 inverted = 1.0 - expanded
                 return inverted.masked_fill(inverted.to(torch.bool), torch.finfo(dtype).min)
-from transformers.models.bloom.modeling_bloom import _make_causal_mask as _make_causal_mask_bloom
+try:
+    from transformers.models.bloom.modeling_bloom import _make_causal_mask as _make_causal_mask_bloom
+except Exception:  # pragma: no cover - bloom helper moved or removed
+    try:
+        from transformers.modeling_attn_mask_utils import make_causal_mask as _hf_make_causal_mask_bloom
+
+        def _make_causal_mask_bloom(input_shape, device=None, past_key_values_length=0):
+            return _hf_make_causal_mask_bloom(
+                input_shape,
+                torch.float32,
+                device=device,
+                past_key_values_length=past_key_values_length,
+            )
+    except Exception:  # pragma: no cover - no helper available
+        def _make_causal_mask_bloom(input_shape, device=None, past_key_values_length=0):
+            bsz, tgt_len = input_shape
+            mask = torch.zeros((tgt_len, tgt_len + past_key_values_length), device=device)
+            mask[:, past_key_values_length:] = torch.triu(
+                torch.full((tgt_len, tgt_len), torch.finfo(torch.float32).min, device=device),
+                diagonal=1,
+            )
+            return mask[None, None, :, :].expand(bsz, 1, tgt_len, tgt_len + past_key_values_length)
 from transformers.models.bloom.modeling_bloom import logging
 from transformers.models.gpt2.modeling_gpt2 import GPT2LMHeadModel
 from transformers.models.gpt_neo.modeling_gpt_neo import GPTNeoForCausalLM
@@ -75,7 +96,28 @@ except Exception:  # pragma: no cover - opt helper moved or removed
                 expanded = expanded.expand(mask.size(0), 1, tgt_length, src_len)
                 inverted = 1.0 - expanded
                 return inverted.masked_fill(inverted.to(torch.bool), torch.finfo(dtype).min)
-from transformers.models.opt.modeling_opt import _make_causal_mask as _make_causal_mask_opt
+try:
+    from transformers.models.opt.modeling_opt import _make_causal_mask as _make_causal_mask_opt
+except Exception:  # pragma: no cover - opt helper moved or removed
+    try:
+        from transformers.modeling_attn_mask_utils import make_causal_mask as _hf_make_causal_mask_opt
+
+        def _make_causal_mask_opt(input_shape, dtype, device=None, past_key_values_length=0):
+            return _hf_make_causal_mask_opt(
+                input_shape,
+                dtype,
+                device=device,
+                past_key_values_length=past_key_values_length,
+            )
+    except Exception:  # pragma: no cover - no helper available
+        def _make_causal_mask_opt(input_shape, dtype, device=None, past_key_values_length=0):
+            bsz, tgt_len = input_shape
+            mask = torch.zeros((tgt_len, tgt_len + past_key_values_length), dtype=dtype, device=device)
+            mask[:, past_key_values_length:] = torch.triu(
+                torch.full((tgt_len, tgt_len), torch.finfo(dtype).min, device=device),
+                diagonal=1,
+            )
+            return mask[None, None, :, :].expand(bsz, 1, tgt_len, tgt_len + past_key_values_length)
 logger = logging.get_logger(__name__)
 _SUPPORTED_GPT_MODELS = (GPT2LMHeadModel, GPTJForCausalLM, GPTNeoForCausalLM, GPTNeoXForCausalLM)
 CAUSAL_GPT_TYPES = Union[GPT2LMHeadModel, GPTJForCausalLM, GPTNeoForCausalLM, GPTNeoXForCausalLM]

--- a/llava/model/language_model/mpt/hf_prefixlm_converter.py
+++ b/llava/model/language_model/mpt/hf_prefixlm_converter.py
@@ -20,13 +20,29 @@ from transformers.models.bloom.modeling_bloom import (
 )
 try:
     from transformers.models.bloom.modeling_bloom import _expand_mask as _expand_mask_bloom
-except ImportError:  # pragma: no cover - fallback for newer Transformers
+except Exception:  # pragma: no cover - bloom helper moved or removed
     try:
-        from transformers.modeling_utils import expand_mask as _expand_mask_bloom
-    except Exception:  # pragma: no cover - fallback for latest Transformers
-        from transformers.modeling_attn_mask_utils import (
-            expand_mask as _expand_mask_bloom,
-        )
+        from transformers.modeling_utils import expand_mask as _hf_expand_mask_bloom
+
+        def _expand_mask_bloom(mask, *, tgt_length=None, dtype=None):
+            dtype = dtype if dtype is not None else mask.dtype
+            return _hf_expand_mask_bloom(mask, dtype, tgt_length)
+    except Exception:  # pragma: no cover - latest transformers
+        try:
+            from transformers.modeling_attn_mask_utils import expand_mask as _hf_expand_mask_bloom
+
+            def _expand_mask_bloom(mask, *, tgt_length=None, dtype=None):
+                dtype = dtype if dtype is not None else mask.dtype
+                return _hf_expand_mask_bloom(mask, dtype, tgt_length)
+        except Exception:  # pragma: no cover - no helper available
+            def _expand_mask_bloom(mask, *, tgt_length=None, dtype=None):
+                dtype = dtype if dtype is not None else mask.dtype
+                src_len = mask.size(-1)
+                tgt_length = src_len if tgt_length is None else tgt_length
+                expanded = mask[:, None, None, :].to(dtype)
+                expanded = expanded.expand(mask.size(0), 1, tgt_length, src_len)
+                inverted = 1.0 - expanded
+                return inverted.masked_fill(inverted.to(torch.bool), torch.finfo(dtype).min)
 from transformers.models.bloom.modeling_bloom import _make_causal_mask as _make_causal_mask_bloom
 from transformers.models.bloom.modeling_bloom import logging
 from transformers.models.gpt2.modeling_gpt2 import GPT2LMHeadModel
@@ -36,13 +52,29 @@ from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
 from transformers.models.opt.modeling_opt import OPTForCausalLM
 try:
     from transformers.models.opt.modeling_opt import _expand_mask as _expand_mask_opt
-except ImportError:  # pragma: no cover - fallback for newer Transformers
+except Exception:  # pragma: no cover - opt helper moved or removed
     try:
-        from transformers.modeling_utils import expand_mask as _expand_mask_opt
-    except Exception:  # pragma: no cover - fallback for latest Transformers
-        from transformers.modeling_attn_mask_utils import (
-            expand_mask as _expand_mask_opt,
-        )
+        from transformers.modeling_utils import expand_mask as _hf_expand_mask_opt
+
+        def _expand_mask_opt(mask, *, tgt_length=None, dtype=None):
+            dtype = dtype if dtype is not None else mask.dtype
+            return _hf_expand_mask_opt(mask, dtype, tgt_length)
+    except Exception:  # pragma: no cover - latest transformers
+        try:
+            from transformers.modeling_attn_mask_utils import expand_mask as _hf_expand_mask_opt
+
+            def _expand_mask_opt(mask, *, tgt_length=None, dtype=None):
+                dtype = dtype if dtype is not None else mask.dtype
+                return _hf_expand_mask_opt(mask, dtype, tgt_length)
+        except Exception:  # pragma: no cover - no helper available
+            def _expand_mask_opt(mask, *, tgt_length=None, dtype=None):
+                dtype = dtype if dtype is not None else mask.dtype
+                src_len = mask.size(-1)
+                tgt_length = src_len if tgt_length is None else tgt_length
+                expanded = mask[:, None, None, :].to(dtype)
+                expanded = expanded.expand(mask.size(0), 1, tgt_length, src_len)
+                inverted = 1.0 - expanded
+                return inverted.masked_fill(inverted.to(torch.bool), torch.finfo(dtype).min)
 from transformers.models.opt.modeling_opt import _make_causal_mask as _make_causal_mask_opt
 logger = logging.get_logger(__name__)
 _SUPPORTED_GPT_MODELS = (GPT2LMHeadModel, GPTJForCausalLM, GPTNeoForCausalLM, GPTNeoXForCausalLM)

--- a/llava/model/language_model/mpt/hf_prefixlm_converter.py
+++ b/llava/model/language_model/mpt/hf_prefixlm_converter.py
@@ -11,8 +11,17 @@ import warnings
 from types import MethodType
 from typing import Any, Dict, List, Optional, Tuple, Union
 import torch
-from transformers.models.bloom.modeling_bloom import BaseModelOutputWithPastAndCrossAttentions, BloomForCausalLM, BloomModel, CausalLMOutputWithCrossAttentions, CrossEntropyLoss
-from transformers.models.bloom.modeling_bloom import _expand_mask as _expand_mask_bloom
+from transformers.models.bloom.modeling_bloom import (
+    BaseModelOutputWithPastAndCrossAttentions,
+    BloomForCausalLM,
+    BloomModel,
+    CausalLMOutputWithCrossAttentions,
+    CrossEntropyLoss,
+)
+try:
+    from transformers.models.bloom.modeling_bloom import _expand_mask as _expand_mask_bloom
+except ImportError:  # pragma: no cover - fallback for newer Transformers
+    from transformers.modeling_utils import expand_mask as _expand_mask_bloom
 from transformers.models.bloom.modeling_bloom import _make_causal_mask as _make_causal_mask_bloom
 from transformers.models.bloom.modeling_bloom import logging
 from transformers.models.gpt2.modeling_gpt2 import GPT2LMHeadModel
@@ -20,7 +29,10 @@ from transformers.models.gpt_neo.modeling_gpt_neo import GPTNeoForCausalLM
 from transformers.models.gpt_neox.modeling_gpt_neox import GPTNeoXForCausalLM
 from transformers.models.gptj.modeling_gptj import GPTJForCausalLM
 from transformers.models.opt.modeling_opt import OPTForCausalLM
-from transformers.models.opt.modeling_opt import _expand_mask as _expand_mask_opt
+try:
+    from transformers.models.opt.modeling_opt import _expand_mask as _expand_mask_opt
+except ImportError:  # pragma: no cover - fallback for newer Transformers
+    from transformers.modeling_utils import expand_mask as _expand_mask_opt
 from transformers.models.opt.modeling_opt import _make_causal_mask as _make_causal_mask_opt
 logger = logging.get_logger(__name__)
 _SUPPORTED_GPT_MODELS = (GPT2LMHeadModel, GPTJForCausalLM, GPTNeoForCausalLM, GPTNeoXForCausalLM)


### PR DESCRIPTION
## Summary
- prevent duplicate 'llava' config/model registration to avoid ValueError

## Testing
- `python -m py_compile llava/model/language_model/llava_llama.py`
- `python generate_text.py "/home/jovyan/work/tran_est/multires_VL_old/output/TCGA-HU-8608-01Z-00-DX1.F40770A6-9384-4381-B6AD-2C488915E73F"` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch transformers` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_b_68c27471be048327af1e3a4b1eddf837