### PR TITLE
Filter multi-scale patches by tissue coverage

### DIFF
--- a/scripts/build_patch_manifest.py
+++ b/scripts/build_patch_manifest.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Build a manifest CSV enumerating sampled patch tiles.
+
+The sampling pipeline stores a ``bags.json`` file for every processed slide
+that describes the multi-resolution hierarchy extracted from each seed.  This
+script flattens those hierarchies into a tabular representation where each row
+contains:
+
+* the patch identifier and filename
+* the slide metadata columns from the balanced selection CSV
+* convenience columns indicating the slide stem, bag index, and scale suffix
+
+Example usage::
+
+    python scripts/build_patch_manifest.py \
+        /path/to/patches \
+        /path/to/patches/selected_wsi.csv \
+        /path/to/patch_manifest.csv
+
+The resulting CSV makes it easy to join patch-level features with the original
+slide metadata when training downstream models.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, MutableMapping, Sequence
+
+
+@dataclass
+class PatchRecord:
+    """Description of a single patch tile."""
+
+    slide_stem: str
+    bag_index: int
+    patch_id: str
+    patch_file: str
+    rel_path: str
+    scale_suffix: str
+
+
+def _load_selection_table(csv_path: Path) -> tuple[List[Dict[str, str]], Sequence[str]]:
+    """Return metadata rows and the header order from ``csv_path``."""
+
+    with csv_path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = [dict(row) for row in reader]
+        if not rows:
+            raise ValueError(f"Selection CSV {csv_path} is empty")
+        return rows, reader.fieldnames or []
+
+
+def _iter_bag_nodes(bag: MutableMapping[str, object]) -> Iterator[MutableMapping[str, object]]:
+    """Yield every node contained within ``bag`` (depth-first)."""
+
+    stack = [bag]
+    while stack:
+        node = stack.pop()
+        yield node
+        children = node.get("children", []) if isinstance(node, dict) else []
+        if isinstance(children, list):
+            for child in reversed(children):
+                if isinstance(child, dict):
+                    stack.append(child)
+
+
+def _collect_patches(bags_path: Path) -> List[PatchRecord]:
+    """Parse ``bags.json`` and return flattened patch descriptors."""
+
+    with bags_path.open() as handle:
+        bags = json.load(handle)
+
+    records: List[PatchRecord] = []
+    slide_stem = bags_path.parent.name
+    for bag_index, bag in enumerate(bags):
+        if not isinstance(bag, dict):
+            continue
+        for node in _iter_bag_nodes(bag):
+            patch_id = str(node.get("id", ""))
+            patch_file = str(node.get("file", ""))
+            if not patch_file:
+                continue
+            rel_path = str(Path(slide_stem) / patch_file)
+            scale_suffix = patch_id.split("_")[-1] if patch_id else ""
+            records.append(
+                PatchRecord(
+                    slide_stem=slide_stem,
+                    bag_index=bag_index,
+                    patch_id=patch_id,
+                    patch_file=patch_file,
+                    rel_path=rel_path,
+                    scale_suffix=scale_suffix,
+                )
+            )
+    return records
+
+
+def build_manifest(
+    patch_root: Path,
+    selection_rows: Iterable[Dict[str, str]],
+    *,
+    slide_column: str,
+    bags_filename: str,
+) -> List[Dict[str, str]]:
+    """Return manifest rows merging metadata with patch descriptors."""
+
+    manifest: List[Dict[str, str]] = []
+
+    for row in selection_rows:
+        slide_value = row.get(slide_column, "").strip()
+        if not slide_value:
+            print(
+                "Warning: skipping metadata row without a value in column "
+                f"'{slide_column}'."
+            )
+            continue
+
+        slide_path = Path(slide_value)
+        slide_stem = slide_path.stem
+        slide_dir = patch_root / slide_stem
+        bags_path = slide_dir / bags_filename
+
+        if not slide_dir.exists():
+            print(
+                f"Warning: patch directory {slide_dir} does not exist; "
+                "skipping."
+            )
+            continue
+        if not bags_path.exists():
+            print(
+                f"Warning: metadata file {bags_path} not found for slide "
+                f"'{slide_stem}'; skipping."
+            )
+            continue
+
+        patch_records = _collect_patches(bags_path)
+        if not patch_records:
+            print(f"Warning: no patch entries found in {bags_path}; skipping.")
+            continue
+
+        for record in patch_records:
+            out_row = dict(row)
+            out_row.update(
+                {
+                    "slide_stem": record.slide_stem,
+                    "bag_index": str(record.bag_index),
+                    "patch_id": record.patch_id,
+                    "patch_file": record.patch_file,
+                    "patch_relpath": record.rel_path,
+                    "patch_scale": record.scale_suffix,
+                }
+            )
+            manifest.append(out_row)
+
+    return manifest
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a CSV manifest describing every patch tile produced "
+            "by the balanced sampling pipeline."
+        )
+    )
+    parser.add_argument(
+        "patch_root",
+        type=Path,
+        help="Directory containing slide-specific patch folders",
+    )
+    parser.add_argument(
+        "selection_csv",
+        type=Path,
+        help="Balanced slide selection CSV generated by the sampler",
+    )
+    parser.add_argument("output_csv", type=Path, help="Destination path for the manifest")
+    parser.add_argument(
+        "--slide-column",
+        type=str,
+        default="resolved_path",
+        help=(
+            "Column in the selection CSV that stores the slide path or name "
+            "used to derive the patch directory."
+        ),
+    )
+    parser.add_argument(
+        "--bags-filename",
+        type=str,
+        default="bags.json",
+        help="Name of the JSON file that contains the sampled bag hierarchy",
+    )
+
+    args = parser.parse_args()
+
+    if not args.patch_root.exists():
+        raise FileNotFoundError(f"Patch directory {args.patch_root} does not exist")
+    if not args.selection_csv.exists():
+        raise FileNotFoundError(f"Selection CSV {args.selection_csv} does not exist")
+
+    rows, fieldnames = _load_selection_table(args.selection_csv)
+    manifest = build_manifest(
+        args.patch_root,
+        rows,
+        slide_column=args.slide_column,
+        bags_filename=args.bags_filename,
+    )
+    if not manifest:
+        raise RuntimeError("No patch rows were collected; nothing to write")
+
+    base_fields = list(fieldnames)
+    extra_fields = [
+        "slide_stem",
+        "bag_index",
+        "patch_id",
+        "patch_file",
+        "patch_relpath",
+        "patch_scale",
+    ]
+    field_order = base_fields + [f for f in extra_fields if f not in base_fields]
+
+    args.output_csv.parent.mkdir(parents=True, exist_ok=True)
+    with args.output_csv.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=field_order)
+        writer.writeheader()
+        for row in manifest:
+            writer.writerow(row)
+
+    print(f"Wrote {len(manifest)} rows to {args.output_csv}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -26,10 +26,12 @@ output patch still reflects the requested field of view.
 from __future__ import annotations
 
 import argparse
+import csv
 import json
 import random
+from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import openslide
 from PIL import Image
@@ -214,6 +216,104 @@ def gather_slides(wsi_root: Path) -> List[Path]:
     return [p for p in wsi_root.rglob("*") if p.suffix.lower() in exts]
 
 
+def load_metadata_table(csv_path: Path) -> Tuple[List[Dict[str, str]], Sequence[str]]:
+    """Read ``csv_path`` and return a list of row dictionaries."""
+
+    with csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        rows = [dict(row) for row in reader]
+        if not rows:
+            raise ValueError(f"Metadata file {csv_path} is empty")
+        return rows, reader.fieldnames or []
+
+
+def select_balanced_subset(
+    rows: Iterable[Dict[str, str]],
+    subtype_col: str,
+    total: int,
+    seed: int,
+) -> List[Dict[str, str]]:
+    """Select ``total`` rows with equal representation of each subtype."""
+
+    grouped: Dict[str, List[Dict[str, str]]] = defaultdict(list)
+    for row in rows:
+        if subtype_col not in row:
+            raise KeyError(f"Column '{subtype_col}' not found in metadata")
+        grouped[row[subtype_col]].append(row)
+
+    if not grouped:
+        raise ValueError("No subtypes found in metadata table")
+
+    num_subtypes = len(grouped)
+    if total % num_subtypes != 0:
+        raise ValueError(
+            "Cannot select an equal number of WSIs per subtype: "
+            f"requested {total} slides across {num_subtypes} subtypes."
+        )
+
+    per_subtype = total // num_subtypes
+    rng = random.Random(seed)
+    selected: List[Dict[str, str]] = []
+    for subtype, items in grouped.items():
+        if len(items) < per_subtype:
+            raise ValueError(
+                f"Not enough entries for subtype '{subtype}': "
+                f"required {per_subtype}, found {len(items)}"
+            )
+        selected.extend(rng.sample(items, per_subtype))
+
+    rng.shuffle(selected)
+    return selected
+
+
+def resolve_selected_slides(
+    slides: Sequence[Path],
+    selected_rows: Sequence[Dict[str, str]],
+    path_column: str,
+) -> List[Tuple[Path, Dict[str, str]]]:
+    """Match selected metadata rows to slide paths."""
+
+    if not slides:
+        return []
+
+    by_name = {p.name: p for p in slides}
+    by_stem: Dict[str, List[Path]] = defaultdict(list)
+    for slide in slides:
+        by_stem[slide.stem].append(slide)
+
+    resolved: List[Tuple[Path, Dict[str, str]]] = []
+    missing: List[str] = []
+    for row in selected_rows:
+        if path_column not in row:
+            raise KeyError(f"Column '{path_column}' not found in metadata")
+        raw_value = row[path_column]
+        if not raw_value:
+            missing.append("<empty>")
+            continue
+        filename = Path(raw_value).name
+        slide_path = by_name.get(filename)
+        if slide_path is None:
+            stem_matches = by_stem.get(Path(filename).stem, [])
+            if len(stem_matches) == 1:
+                slide_path = stem_matches[0]
+            elif len(stem_matches) > 1:
+                raise ValueError(
+                    f"Multiple slide files match '{raw_value}'. Please disambiguate."
+                )
+        if slide_path is None:
+            missing.append(raw_value)
+        else:
+            resolved.append((slide_path, row))
+
+    if missing:
+        raise FileNotFoundError(
+            "Slides listed in metadata were not found under the provided directory: "
+            + ", ".join(sorted(set(missing)))
+        )
+
+    return resolved
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Sample multi-resolution patch bags from WSIs")
@@ -238,6 +338,29 @@ def main() -> None:
         default=220,
         help="Grayscale threshold separating tissue from background",
     )
+    parser.add_argument(
+        "--metadata-csv",
+        type=Path,
+        help="CSV file describing slides and their subtypes",
+    )
+    parser.add_argument(
+        "--metadata-subtype-column",
+        type=str,
+        default="subtype",
+        help="Column in the metadata CSV that stores subtype labels",
+    )
+    parser.add_argument(
+        "--metadata-path-column",
+        type=str,
+        default="pathology_id",
+        help="Column in the metadata CSV that stores slide file names",
+    )
+    parser.add_argument(
+        "--num-wsi",
+        type=int,
+        default=50,
+        help="Number of WSIs to sample evenly across subtypes",
+    )
 
     args = parser.parse_args()
 
@@ -245,7 +368,46 @@ def main() -> None:
     if not slides:
         raise FileNotFoundError(f"No WSI files found at {args.wsi_dir}")
 
-    for slide_path in slides:
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    selected_rows: Optional[List[Dict[str, str]]] = None
+    if args.metadata_csv is not None:
+        metadata_rows, fieldnames = load_metadata_table(args.metadata_csv)
+        selected_rows = select_balanced_subset(
+            metadata_rows,
+            args.metadata_subtype_column,
+            args.num_wsi,
+            args.seed,
+        )
+        resolved = resolve_selected_slides(
+            slides,
+            selected_rows,
+            args.metadata_path_column,
+        )
+        slides_to_process = [path for path, _ in resolved]
+        if len(slides_to_process) != len(selected_rows):
+            raise RuntimeError("Mismatch between selected metadata rows and slide paths")
+
+        output_fields: Sequence[str] = (
+            list(fieldnames) if fieldnames else list(selected_rows[0].keys())
+        )
+        if "resolved_path" not in output_fields:
+            output_fields = list(output_fields) + ["resolved_path"]
+        selected_csv_path = args.out_dir / "selected_wsi.csv"
+        with selected_csv_path.open("w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=output_fields)
+            writer.writeheader()
+            for slide_path, row in resolved:
+                row_out = dict(row)
+                row_out["resolved_path"] = str(slide_path)
+                writer.writerow(row_out)
+    else:
+        slides_to_process = slides
+
+    if not slides_to_process:
+        raise FileNotFoundError("No slides matched the selection criteria")
+
+    for slide_path in slides_to_process:
         print(f"Processing {slide_path}")
         process_wsi(
             slide_path,

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -227,24 +227,84 @@ def load_metadata_table(csv_path: Path) -> Tuple[List[Dict[str, str]], Sequence[
         return rows, reader.fieldnames or []
 
 
-def select_balanced_subset(
+def _index_slide_paths(slides: Sequence[Path]) -> Tuple[Dict[str, Path], Dict[str, List[Path]]]:
+    """Return lookup tables for slide files keyed by name and stem."""
+
+    by_name = {p.name: p for p in slides}
+    by_stem: Dict[str, List[Path]] = defaultdict(list)
+    for slide in slides:
+        by_stem[slide.stem].append(slide)
+    return by_name, by_stem
+
+
+def _match_slide_path(
+    raw_value: str,
+    by_name: Dict[str, Path],
+    by_stem: Dict[str, List[Path]],
+) -> Optional[Path]:
+    """Resolve ``raw_value`` to a slide ``Path`` if possible."""
+
+    if not raw_value:
+        return None
+
+    filename = Path(raw_value).name
+    slide_path = by_name.get(filename)
+    if slide_path is not None:
+        return slide_path
+
+    stem_matches = by_stem.get(Path(filename).stem, [])
+    if len(stem_matches) == 1:
+        return stem_matches[0]
+    if len(stem_matches) > 1:
+        raise ValueError(
+            f"Multiple slide files match '{raw_value}'. Please disambiguate."
+        )
+    return None
+
+
+def select_balanced_slide_subset(
     rows: Iterable[Dict[str, str]],
     subtype_col: str,
+    path_column: str,
     total: int,
     seed: int,
-) -> List[Dict[str, str]]:
-    """Select ``total`` rows with equal representation of each subtype."""
+    slides: Sequence[Path],
+) -> List[Tuple[Path, Dict[str, str]]]:
+    """Select ``total`` slide/metadata pairs with equal subtype representation."""
 
-    grouped: Dict[str, List[Dict[str, str]]] = defaultdict(list)
+    if not slides:
+        return []
+
+    by_name, by_stem = _index_slide_paths(slides)
+
+    grouped: Dict[str, List[Tuple[Path, Dict[str, str]]]] = defaultdict(list)
+    all_subtypes: set[str] = set()
+    skipped: Dict[str, int] = defaultdict(int)
+
     for row in rows:
         if subtype_col not in row:
             raise KeyError(f"Column '{subtype_col}' not found in metadata")
-        grouped[row[subtype_col]].append(row)
+        if path_column not in row:
+            raise KeyError(f"Column '{path_column}' not found in metadata")
 
-    if not grouped:
+        subtype = row[subtype_col]
+        all_subtypes.add(subtype)
+        raw_value = row[path_column]
+        slide_path = _match_slide_path(raw_value, by_name, by_stem)
+        if slide_path is None:
+            skipped[raw_value or "<empty>"] += 1
+            continue
+
+        existing_paths = {path for path, _ in grouped[subtype]}
+        if slide_path in existing_paths:
+            continue
+
+        grouped[subtype].append((slide_path, row))
+
+    if not all_subtypes:
         raise ValueError("No subtypes found in metadata table")
 
-    num_subtypes = len(grouped)
+    num_subtypes = len(all_subtypes)
     if total % num_subtypes != 0:
         raise ValueError(
             "Cannot select an equal number of WSIs per subtype: "
@@ -252,66 +312,32 @@ def select_balanced_subset(
         )
 
     per_subtype = total // num_subtypes
-    rng = random.Random(seed)
-    selected: List[Dict[str, str]] = []
-    for subtype, items in grouped.items():
-        if len(items) < per_subtype:
+
+    for subtype in sorted(all_subtypes):
+        available = grouped.get(subtype, [])
+        if len(available) < per_subtype:
             raise ValueError(
-                f"Not enough entries for subtype '{subtype}': "
-                f"required {per_subtype}, found {len(items)}"
+                f"Not enough resolvable slides for subtype '{subtype}': "
+                f"required {per_subtype}, found {len(available)}"
             )
-        selected.extend(rng.sample(items, per_subtype))
+
+    total_skipped = sum(skipped.values())
+    if total_skipped:
+        skipped_examples = ", ".join(sorted(skipped.keys())[:5])
+        print(
+            "Warning: skipped "
+            f"{total_skipped} metadata rows without matching slides"
+            f" (examples: {skipped_examples})."
+        )
+
+    rng = random.Random(seed)
+    selected: List[Tuple[Path, Dict[str, str]]] = []
+    for subtype in sorted(all_subtypes):
+        candidates = grouped[subtype]
+        selected.extend(rng.sample(candidates, per_subtype))
 
     rng.shuffle(selected)
     return selected
-
-
-def resolve_selected_slides(
-    slides: Sequence[Path],
-    selected_rows: Sequence[Dict[str, str]],
-    path_column: str,
-) -> List[Tuple[Path, Dict[str, str]]]:
-    """Match selected metadata rows to slide paths."""
-
-    if not slides:
-        return []
-
-    by_name = {p.name: p for p in slides}
-    by_stem: Dict[str, List[Path]] = defaultdict(list)
-    for slide in slides:
-        by_stem[slide.stem].append(slide)
-
-    resolved: List[Tuple[Path, Dict[str, str]]] = []
-    missing: List[str] = []
-    for row in selected_rows:
-        if path_column not in row:
-            raise KeyError(f"Column '{path_column}' not found in metadata")
-        raw_value = row[path_column]
-        if not raw_value:
-            missing.append("<empty>")
-            continue
-        filename = Path(raw_value).name
-        slide_path = by_name.get(filename)
-        if slide_path is None:
-            stem_matches = by_stem.get(Path(filename).stem, [])
-            if len(stem_matches) == 1:
-                slide_path = stem_matches[0]
-            elif len(stem_matches) > 1:
-                raise ValueError(
-                    f"Multiple slide files match '{raw_value}'. Please disambiguate."
-                )
-        if slide_path is None:
-            missing.append(raw_value)
-        else:
-            resolved.append((slide_path, row))
-
-    if missing:
-        raise FileNotFoundError(
-            "Slides listed in metadata were not found under the provided directory: "
-            + ", ".join(sorted(set(missing)))
-        )
-
-    return resolved
 
 
 def main() -> None:
@@ -373,20 +399,16 @@ def main() -> None:
     selected_rows: Optional[List[Dict[str, str]]] = None
     if args.metadata_csv is not None:
         metadata_rows, fieldnames = load_metadata_table(args.metadata_csv)
-        selected_rows = select_balanced_subset(
+        selected_pairs = select_balanced_slide_subset(
             metadata_rows,
             args.metadata_subtype_column,
+            args.metadata_path_column,
             args.num_wsi,
             args.seed,
-        )
-        resolved = resolve_selected_slides(
             slides,
-            selected_rows,
-            args.metadata_path_column,
         )
-        slides_to_process = [path for path, _ in resolved]
-        if len(slides_to_process) != len(selected_rows):
-            raise RuntimeError("Mismatch between selected metadata rows and slide paths")
+        slides_to_process = [path for path, _ in selected_pairs]
+        selected_rows = [row for _, row in selected_pairs]
 
         output_fields: Sequence[str] = (
             list(fieldnames) if fieldnames else list(selected_rows[0].keys())
@@ -397,7 +419,7 @@ def main() -> None:
         with selected_csv_path.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=output_fields)
             writer.writeheader()
-            for slide_path, row in resolved:
+            for slide_path, row in selected_pairs:
                 row_out = dict(row)
                 row_out["resolved_path"] = str(slide_path)
                 writer.writerow(row_out)

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -29,10 +29,23 @@ import argparse
 import json
 import random
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import openslide
 from PIL import Image
+import numpy as np
+
+
+def compute_tissue_fraction(img: Image.Image, background_threshold: int = 220) -> float:
+    """Return the fraction of pixels that are likely to be tissue.
+
+    Pixels lighter than ``background_threshold`` (in grayscale) are considered
+    background and excluded from the tissue count.
+    """
+
+    gray = np.array(img.convert("L"))
+    tissue_mask = gray < background_threshold
+    return float(tissue_mask.mean())
 
 
 def save_patch(
@@ -43,8 +56,10 @@ def save_patch(
     size: int,
     requested_ds: float,
     out_path: Path,
-) -> None:
-    """Read and save a region from ``slide`` at the desired downsample."""
+    tissue_threshold: float,
+    background_threshold: int,
+) -> Optional[Path]:
+    """Read and save a region from ``slide`` if it contains sufficient tissue."""
 
     actual_ds = slide.level_downsamples[level]
     # Compute region in level-0 coordinates covering the requested area
@@ -55,7 +70,11 @@ def save_patch(
     img = slide.read_region((x0, y0), level, (region_size, region_size)).convert("RGB")
     if region_size != size:
         img = img.resize((size, size), Image.BILINEAR)
+    tissue_fraction = compute_tissue_fraction(img, background_threshold)
+    if tissue_fraction < tissue_threshold:
+        return None
     img.save(out_path)
+    return out_path
 
 
 def generate_hierarchy(
@@ -67,7 +86,9 @@ def generate_hierarchy(
     out_dir: Path,
     base_mpp: float,
     size: int = 512,
-) -> Dict:
+    tissue_threshold: float = 0.75,
+    background_threshold: int = 220,
+) -> Optional[Dict[str, object]]:
     """Generate a chain of patches centered at ``(center_x, center_y)``.
 
     The first entry in ``mpps`` corresponds to the coarsest magnification
@@ -85,7 +106,19 @@ def generate_hierarchy(
     suffix = mag_map.get(mpp, f"{mpp:.2f}mpp")
     patch_id = f"{prefix}_{suffix}"
     out_path = out_dir / f"{patch_id}.png"
-    save_patch(slide, center_x, center_y, level, size, requested_ds, out_path)
+    saved_path = save_patch(
+        slide,
+        center_x,
+        center_y,
+        level,
+        size,
+        requested_ds,
+        out_path,
+        tissue_threshold,
+        background_threshold,
+    )
+    if saved_path is None:
+        return None
 
     node: Dict[str, object] = {"id": patch_id, "file": out_path.name, "children": []}
     if len(mpps) > 1:
@@ -98,13 +131,22 @@ def generate_hierarchy(
             out_dir,
             base_mpp,
             size,
+            tissue_threshold,
+            background_threshold,
         )
+        if not child:
+            try:
+                out_path.unlink()
+            except FileNotFoundError:
+                pass
+            return None
         node["children"].append(child)
     return node
 
 
 def process_wsi(slide_path: Path, out_root: Path, num_parents: int = 20,
-                seed: int = 0) -> None:
+                seed: int = 0, tissue_threshold: float = 0.75,
+                background_threshold: int = 220) -> None:
     """Process a single WSI and generate multi-scale patch bags."""
     random.seed(seed)
     slide = openslide.OpenSlide(str(slide_path))
@@ -124,7 +166,11 @@ def process_wsi(slide_path: Path, out_root: Path, num_parents: int = 20,
     max_cy = slide_height - margin
 
     bags = []
-    for i in range(num_parents):
+    i = 0
+    attempts = 0
+    max_attempts = num_parents * 20 if num_parents > 0 else 0
+    while i < num_parents and (max_attempts == 0 or attempts < max_attempts):
+        attempts += 1
         center_x = random.randint(margin, max_cx)
         center_y = random.randint(margin, max_cy)
         prefix = f"patch_{i}"
@@ -137,8 +183,18 @@ def process_wsi(slide_path: Path, out_root: Path, num_parents: int = 20,
             out_dir,
             base_mpp,
             size,
+            tissue_threshold,
+            background_threshold,
         )
-        bags.append(bag)
+        if bag:
+            bags.append(bag)
+            i += 1
+
+    if i < num_parents:
+        print(
+            f"Warning: only collected {i} patch bags (requested {num_parents}) "
+            f"for {slide_path.name}."
+        )
 
     with open(out_dir / "bags.json", "w") as f:
         json.dump(bags, f, indent=2)
@@ -170,6 +226,18 @@ def main() -> None:
     parser.add_argument("--num_parents", type=int, default=20,
                         help="Number of parent patches per slide")
     parser.add_argument("--seed", type=int, default=0, help="Random seed")
+    parser.add_argument(
+        "--tissue-threshold",
+        type=float,
+        default=0.75,
+        help="Minimum tissue fraction required to keep a patch",
+    )
+    parser.add_argument(
+        "--background-threshold",
+        type=int,
+        default=220,
+        help="Grayscale threshold separating tissue from background",
+    )
 
     args = parser.parse_args()
 
@@ -184,6 +252,8 @@ def main() -> None:
             args.out_dir,
             num_parents=args.num_parents,
             seed=args.seed,
+            tissue_threshold=args.tissue_threshold,
+            background_threshold=args.background_threshold,
         )
 
 

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -29,7 +29,9 @@ import argparse
 import csv
 import json
 import random
+import shutil
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -146,10 +148,18 @@ def generate_hierarchy(
     return node
 
 
-def process_wsi(slide_path: Path, out_root: Path, num_parents: int = 20,
-                seed: int = 0, tissue_threshold: float = 0.75,
-                background_threshold: int = 220) -> None:
-    """Process a single WSI and generate multi-scale patch bags."""
+def process_wsi(
+    slide_path: Path,
+    out_root: Path,
+    num_parents: int = 20,
+    seed: int = 0,
+    tissue_threshold: float = 0.75,
+    background_threshold: int = 220,
+) -> int:
+    """Process a single WSI and generate multi-scale patch bags.
+
+    Returns the number of patch bags successfully collected.
+    """
     random.seed(seed)
     slide = openslide.OpenSlide(str(slide_path))
     base_mpp = float(slide.properties.get("openslide.mpp-x", 0.25))
@@ -203,6 +213,8 @@ def process_wsi(slide_path: Path, out_root: Path, num_parents: int = 20,
 
     slide.close()
 
+    return len(bags)
+
 
 def gather_slides(wsi_root: Path) -> List[Path]:
     """Return a list of WSI files under ``wsi_root``.
@@ -225,6 +237,16 @@ def load_metadata_table(csv_path: Path) -> Tuple[List[Dict[str, str]], Sequence[
         if not rows:
             raise ValueError(f"Metadata file {csv_path} is empty")
         return rows, reader.fieldnames or []
+
+
+@dataclass
+class BalancedSelection:
+    """Container describing balanced slide sampling results."""
+
+    initial: List[Tuple[Path, Dict[str, str]]]
+    extras: Dict[str, List[Tuple[Path, Dict[str, str]]]]
+    per_subtype: int
+    subtypes: List[str]
 
 
 def _index_slide_paths(slides: Sequence[Path]) -> Tuple[Dict[str, Path], Dict[str, List[Path]]]:
@@ -269,7 +291,7 @@ def select_balanced_slide_subset(
     total: int,
     seed: int,
     slides: Sequence[Path],
-) -> List[Tuple[Path, Dict[str, str]]]:
+) -> BalancedSelection:
     """Select ``total`` slide/metadata pairs with equal subtype representation."""
 
     if not slides:
@@ -331,13 +353,24 @@ def select_balanced_slide_subset(
         )
 
     rng = random.Random(seed)
-    selected: List[Tuple[Path, Dict[str, str]]] = []
-    for subtype in sorted(all_subtypes):
-        candidates = grouped[subtype]
-        selected.extend(rng.sample(candidates, per_subtype))
+    subtype_order = sorted(all_subtypes)
+    initial: List[Tuple[Path, Dict[str, str]]] = []
+    extras: Dict[str, List[Tuple[Path, Dict[str, str]]]] = {}
 
-    rng.shuffle(selected)
-    return selected
+    for subtype in subtype_order:
+        candidates = list(grouped[subtype])
+        rng.shuffle(candidates)
+        initial.extend(candidates[:per_subtype])
+        extras[subtype] = candidates[per_subtype:]
+
+    rng.shuffle(initial)
+
+    return BalancedSelection(
+        initial=initial,
+        extras=extras,
+        per_subtype=per_subtype,
+        subtypes=subtype_order,
+    )
 
 
 def main() -> None:
@@ -396,10 +429,9 @@ def main() -> None:
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
 
-    selected_rows: Optional[List[Dict[str, str]]] = None
     if args.metadata_csv is not None:
         metadata_rows, fieldnames = load_metadata_table(args.metadata_csv)
-        selected_pairs = select_balanced_slide_subset(
+        selection = select_balanced_slide_subset(
             metadata_rows,
             args.metadata_subtype_column,
             args.metadata_path_column,
@@ -407,11 +439,73 @@ def main() -> None:
             args.seed,
             slides,
         )
-        slides_to_process = [path for path, _ in selected_pairs]
-        selected_rows = [row for _, row in selected_pairs]
+        counts = {subtype: 0 for subtype in selection.subtypes}
+        accepted_pairs: List[Tuple[Path, Dict[str, str]]] = []
+
+        def process_candidate(
+            pair: Tuple[Path, Dict[str, str]], *, is_replacement: bool = False
+        ) -> bool:
+            slide_path, row = pair
+            subtype = row[args.metadata_subtype_column]
+            print(f"Processing {slide_path}")
+            bags_collected = process_wsi(
+                slide_path,
+                args.out_dir,
+                num_parents=args.num_parents,
+                seed=args.seed,
+                tissue_threshold=args.tissue_threshold,
+                background_threshold=args.background_threshold,
+            )
+            if bags_collected < args.num_parents:
+                slide_out_dir = args.out_dir / slide_path.stem
+                if slide_out_dir.exists():
+                    shutil.rmtree(slide_out_dir, ignore_errors=True)
+                reason = "replacement" if is_replacement else "selected"
+                print(
+                    f"Scheduling an additional slide for subtype '{subtype}' "
+                    f"because {slide_path.name} ({reason}) yielded "
+                    f"{bags_collected} patch bags."
+                )
+                return False
+
+            counts[subtype] += 1
+            accepted_pairs.append(pair)
+            return True
+
+        for pair in selection.initial:
+            process_candidate(pair)
+
+        for subtype in selection.subtypes:
+            while counts[subtype] < selection.per_subtype:
+                extras = selection.extras[subtype]
+                if not extras:
+                    raise RuntimeError(
+                        "Ran out of candidate slides for subtype "
+                        f"'{subtype}' while attempting to collect "
+                        f"{selection.per_subtype} slides with at least "
+                        f"{args.num_parents} patch bags."
+                    )
+                replacement_pair = extras.pop()
+                process_candidate(replacement_pair, is_replacement=True)
+
+        if any(count < selection.per_subtype for count in counts.values()):
+            raise RuntimeError(
+                "Unable to assemble the requested balanced subset with "
+                f"{args.num_parents} patch bags per slide."
+            )
+
+        expected_total = selection.per_subtype * len(selection.subtypes)
+        if len(accepted_pairs) != expected_total:
+            raise RuntimeError(
+                "Internal error: collected slide count does not match the "
+                "requested balanced sample size."
+            )
+
+        if not accepted_pairs:
+            raise RuntimeError("No slides produced the required patch bags")
 
         output_fields: Sequence[str] = (
-            list(fieldnames) if fieldnames else list(selected_rows[0].keys())
+            list(fieldnames) if fieldnames else list(accepted_pairs[0][1].keys())
         )
         if "resolved_path" not in output_fields:
             output_fields = list(output_fields) + ["resolved_path"]
@@ -419,26 +513,21 @@ def main() -> None:
         with selected_csv_path.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=output_fields)
             writer.writeheader()
-            for slide_path, row in selected_pairs:
+            for slide_path, row in accepted_pairs:
                 row_out = dict(row)
                 row_out["resolved_path"] = str(slide_path)
                 writer.writerow(row_out)
     else:
-        slides_to_process = slides
-
-    if not slides_to_process:
-        raise FileNotFoundError("No slides matched the selection criteria")
-
-    for slide_path in slides_to_process:
-        print(f"Processing {slide_path}")
-        process_wsi(
-            slide_path,
-            args.out_dir,
-            num_parents=args.num_parents,
-            seed=args.seed,
-            tissue_threshold=args.tissue_threshold,
-            background_threshold=args.background_threshold,
-        )
+        for slide_path in slides:
+            print(f"Processing {slide_path}")
+            process_wsi(
+                slide_path,
+                args.out_dir,
+                num_parents=args.num_parents,
+                seed=args.seed,
+                tissue_threshold=args.tissue_threshold,
+                background_threshold=args.background_threshold,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a tissue coverage check to the multi-scale patch sampling script
- skip candidate patches that do not meet the minimum tissue fraction while warning when quotas are unmet

## Testing
- python -m compileall scripts/sample_tcga_multiscale_patches.py

------
https://chatgpt.com/codex/tasks/task_b_68da3a7a734c8327bd3897c44b9880e5