### PR TITLE
Restrict TCGA multiscale patch sampling to XML annotation regions

### DIFF
--- a/scripts/sample_camelyon_multiscale_patches.py
+++ b/scripts/sample_camelyon_multiscale_patches.py
@@ -41,6 +41,111 @@ from sample_tcga_multiscale_patches import (
 )
 
 
+def _extract_group_metadata(root: ET.Element) -> Dict[str, Dict[str, object]]:
+    """Return descriptive metadata for ``Group`` elements keyed by their name."""
+
+    def _clean(text: Optional[str]) -> Optional[str]:
+        if text is None:
+            return None
+        stripped = text.strip()
+        return stripped if stripped else None
+
+    group_lookup: Dict[str, Dict[str, object]] = {}
+    for group in root.findall(".//Group"):
+        raw_name = _clean(group.get("Name") or group.get("name"))
+        if not raw_name:
+            continue
+        lower_name = raw_name.lower()
+        labels: List[str] = []
+
+        attr_parent = group.find("Attributes")
+        if attr_parent is not None:
+            for attribute in attr_parent.findall("Attribute"):
+                attr_value = _clean(attribute.get("Value") or attribute.get("value"))
+                attr_name = _clean(attribute.get("Name") or attribute.get("name"))
+                if attr_value:
+                    labels.append(attr_value)
+                elif attr_name:
+                    labels.append(attr_name)
+
+        if not labels:
+            labels.append(raw_name)
+
+        tumor_like = any(
+            token in label.lower()
+            for label in labels
+            for token in ("tumor", "metast", "positive")
+        )
+        negative_like = any(
+            token in label.lower()
+            for label in labels
+            for token in ("normal", "negative", "exclusion", "exclude")
+        )
+
+        group_lookup[lower_name] = {
+            "labels": labels,
+            "is_tumor": tumor_like and not negative_like,
+            "is_negative": negative_like and not tumor_like,
+        }
+
+    return group_lookup
+
+
+def _annotation_is_tumor(
+    annotation: ET.Element,
+    group_lookup: Dict[str, Dict[str, object]],
+) -> bool:
+    """Heuristically determine if an annotation polygon marks tumor tissue."""
+
+    def _clean(text: Optional[str]) -> Optional[str]:
+        if text is None:
+            return None
+        stripped = text.strip()
+        return stripped if stripped else None
+
+    def _classify(text: str) -> Optional[bool]:
+        lower = text.lower()
+        if any(token in lower for token in ("tumor", "metast", "positive")):
+            return True
+        if any(token in lower for token in ("normal", "negative", "exclusion", "exclude")):
+            return False
+        return None
+
+    candidates: List[str] = []
+    part_of_group = _clean(annotation.get("PartOfGroup") or annotation.get("partOfGroup"))
+    if part_of_group:
+        candidates.append(part_of_group)
+        group = group_lookup.get(part_of_group.lower())
+        if group:
+            candidates.extend(group.get("labels", []))
+            if group.get("is_tumor"):
+                return True
+            if group.get("is_negative"):
+                return False
+
+    name_attr = _clean(annotation.get("Name") or annotation.get("name"))
+    if name_attr:
+        candidates.append(name_attr)
+
+    attr_parent = annotation.find("Attributes")
+    if attr_parent is not None:
+        for attribute in attr_parent.findall("Attribute"):
+            attr_value = _clean(attribute.get("Value") or attribute.get("value"))
+            attr_name = _clean(attribute.get("Name") or attribute.get("name"))
+            if attr_value:
+                candidates.append(attr_value)
+            if attr_name:
+                candidates.append(attr_name)
+
+    for candidate in candidates:
+        classification = _classify(candidate)
+        if classification is not None:
+            return classification
+
+    # Default to tumor: Camelyon annotations typically describe tumor regions.
+    return True
+
+
 def parse_camelyon_xml(xml_path: Path) -> List[AnnotationRegion]:
     """Parse tumor polygons from a Camelyon XML annotation file."""
 
@@ -52,16 +157,13 @@ def parse_camelyon_xml(xml_path: Path) -> List[AnnotationRegion]:
     root = tree.getroot()
 
     polygons: List[AnnotationRegion] = []
+    group_lookup = _extract_group_metadata(root)
     for annotation in root.findall(".//Annotation"):
         type_attr = (annotation.get("Type") or annotation.get("type") or "").lower()
         if type_attr and type_attr != "polygon":
             continue
 
-        part_of_group = (annotation.get("PartOfGroup") or annotation.get("partOfGroup") or "").lower()
-        name_attr = (annotation.get("Name") or annotation.get("name") or "").lower()
-        if part_of_group and "tumor" not in part_of_group:
-            continue
-        if not part_of_group and name_attr and "tumor" not in name_attr:
+        if not _annotation_is_tumor(annotation, group_lookup):
             continue
 
         coordinates_parent = annotation.find(".//Coordinates")

--- a/scripts/sample_camelyon_multiscale_patches.py
+++ b/scripts/sample_camelyon_multiscale_patches.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Sample multi-scale patches for the Camelyon dataset.
+
+The Camelyon16 dataset ships Aperio TIFF whole-slide images accompanied by
+XML annotations that describe tumor polygons.  This script mirrors the
+multi-scale sampling strategy implemented for the TCGA pipeline while adding
+Camelyon-specific handling:
+
+* tumor seed locations are drawn from the provided polygons
+* normal seed locations avoid every tumor polygon
+* each saved patch hierarchy is recorded in ``bags.json`` alongside a
+  ``patches.csv`` manifest that stores per-scale metadata and tumor/normal
+  labels.
+
+By default the script collects an equal number of tumor and normal bags for
+every slide.  The magnification chain matches the TCGA workflow (5×, 10×, 20×,
+and 40× equivalents) so downstream models can reuse the exported data without
+modification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+import xml.etree.ElementTree as ET
+
+import openslide
+
+from sample_tcga_multiscale_patches import (
+    AnnotationRegion,
+    PatchTile,
+    PolygonSampler,
+    ValueLabelEncoder,
+    generate_hierarchy,
+    gather_slides,
+    point_in_polygon,
+)
+
+
+def parse_camelyon_xml(xml_path: Path) -> List[AnnotationRegion]:
+    """Parse tumor polygons from a Camelyon XML annotation file."""
+
+    try:
+        tree = ET.parse(xml_path)
+    except ET.ParseError as exc:
+        print(f"Warning: failed to parse annotation file {xml_path}: {exc}")
+        return []
+    root = tree.getroot()
+
+    polygons: List[AnnotationRegion] = []
+    for annotation in root.findall(".//Annotation"):
+        type_attr = (annotation.get("Type") or annotation.get("type") or "").lower()
+        if type_attr and type_attr != "polygon":
+            continue
+
+        part_of_group = (annotation.get("PartOfGroup") or annotation.get("partOfGroup") or "").lower()
+        name_attr = (annotation.get("Name") or annotation.get("name") or "").lower()
+        if part_of_group and "tumor" not in part_of_group:
+            continue
+        if not part_of_group and name_attr and "tumor" not in name_attr:
+            continue
+
+        coordinates_parent = annotation.find(".//Coordinates")
+        if coordinates_parent is None:
+            continue
+
+        points: List[Tuple[float, float]] = []
+        for coord in coordinates_parent.findall("Coordinate"):
+            x_val = coord.get("X") or coord.get("x")
+            y_val = coord.get("Y") or coord.get("y")
+            if x_val is None or y_val is None:
+                continue
+            try:
+                points.append((float(x_val), float(y_val)))
+            except ValueError:
+                continue
+        if len(points) >= 3:
+            polygons.append(AnnotationRegion(points=points, value="Tumor"))
+
+    return polygons
+
+
+def locate_annotation_file(slide_path: Path, annotation_root: Optional[Path]) -> Optional[Path]:
+    """Return the XML file paired with ``slide_path`` if available."""
+
+    candidates: List[Path] = []
+    if annotation_root is not None:
+        root_path = annotation_root
+        if root_path.is_dir():
+            candidates.extend(
+                [
+                    root_path / f"{slide_path.stem}.xml",
+                    root_path / f"{slide_path.name}.xml",
+                    root_path / f"{slide_path.stem.upper()}.xml",
+                    root_path / f"{slide_path.stem.lower()}.xml",
+                ]
+            )
+        elif root_path.is_file():
+            candidates.append(root_path)
+    candidates.append(slide_path.with_suffix(".xml"))
+
+    for candidate in candidates:
+        if candidate.exists() and candidate.is_file():
+            return candidate
+    return None
+
+
+def _generate_patient_id(slide_path: Path) -> str:
+    seed = abs(hash(slide_path.stem.lower())) % 10**12
+    return f"{seed:012d}"
+
+
+def _corners_overlap(
+    center_x: float,
+    center_y: float,
+    margin: float,
+    polygon: Sequence[Tuple[float, float]],
+) -> bool:
+    offsets = [
+        (-margin, -margin),
+        (-margin, margin),
+        (margin, -margin),
+        (margin, margin),
+    ]
+    for dx, dy in offsets:
+        if point_in_polygon(center_x + dx, center_y + dy, polygon):
+            return True
+    return False
+
+
+def _intersects_polygons(
+    center_x: int,
+    center_y: int,
+    margin: float,
+    polygons: Sequence[AnnotationRegion],
+) -> bool:
+    for region in polygons:
+        polygon = region.points
+        if point_in_polygon(center_x, center_y, polygon):
+            return True
+        if _corners_overlap(center_x, center_y, margin, polygon):
+            return True
+    return False
+
+
+def _sample_negative_center(
+    width: int,
+    height: int,
+    margin_int: int,
+    margin: float,
+    polygons: Sequence[AnnotationRegion],
+    max_attempts: int = 4000,
+) -> Optional[Tuple[int, int]]:
+    for _ in range(max_attempts):
+        center_x = random.randint(margin_int, width - margin_int)
+        center_y = random.randint(margin_int, height - margin_int)
+        if not _intersects_polygons(center_x, center_y, margin, polygons):
+            return center_x, center_y
+    return None
+
+
+def _ensure_output_dir(out_root: Path, slide_path: Path) -> Path:
+    out_dir = out_root / slide_path.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _record_patch_rows(
+    rows: List[Dict[str, str]],
+    tiles: Sequence[PatchTile],
+    patient_id: str,
+    slide_path: Path,
+    bag_index: int,
+    label_name: str,
+    label_id: int,
+) -> None:
+    for tile in tiles:
+        rows.append(
+            {
+                "patient_id": patient_id,
+                "pathology_id": slide_path.name,
+                "subtype": label_name,
+                "labels": str(label_id),
+                "resolved_path": str(slide_path),
+                "slide_stem": slide_path.stem,
+                "bag_index": str(bag_index),
+                "bag_label": label_name,
+                "bag_label_id": str(label_id),
+                "patch_id": tile.patch_id,
+                "patch_file": tile.patch_file,
+                "patch_path": str(tile.patch_path),
+                "patch_scale": tile.scale_suffix,
+            }
+        )
+
+
+def sample_camelyon_slide(
+    slide_path: Path,
+    out_root: Path,
+    tumor_polygons: Sequence[AnnotationRegion],
+    tumor_bags: int,
+    normal_bags: int,
+    seed: int,
+    target_mpps: Sequence[float],
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+    label_encoder: ValueLabelEncoder,
+) -> Tuple[List[Dict[str, object]], List[Dict[str, str]]]:
+    random.seed(seed)
+
+    slide = openslide.OpenSlide(str(slide_path))
+    base_mpp = float(slide.properties.get("openslide.mpp-x", 0.25))
+    width, height = slide.dimensions
+    out_dir = _ensure_output_dir(out_root, slide_path)
+
+    if not target_mpps:
+        raise ValueError("At least one magnification (mpp) value must be provided")
+
+    parent_ds = target_mpps[0] / base_mpp
+    margin = patch_size * parent_ds / 2
+    margin_int = int(margin)
+    if width <= 2 * margin_int or height <= 2 * margin_int:
+        raise ValueError(
+            f"Slide {slide_path} is too small ({width}x{height}) for the requested patch size"
+        )
+
+    sampler: Optional[PolygonSampler] = None
+    if tumor_polygons:
+        sampler = PolygonSampler(tumor_polygons, margin, width, height)
+        if not sampler.is_available():
+            print(
+                "Warning: tumor polygons for",
+                slide_path.name,
+                "are too small to fit the requested patch hierarchy.",
+            )
+            sampler = None
+
+    patient_id = _generate_patient_id(slide_path)
+    bags: List[Dict[str, object]] = []
+    patch_rows: List[Dict[str, str]] = []
+    bag_index = 0
+
+    tumor_label_id, tumor_label_name = label_encoder.encode("Tumor")
+    normal_label_id, normal_label_name = label_encoder.encode("Normal")
+
+    collected_tumor = 0
+    if tumor_bags > 0 and sampler is None:
+        print(
+            f"Warning: unable to collect tumor patches for {slide_path.name} because "
+            "no valid polygons were found.",
+        )
+
+    while sampler is not None and collected_tumor < tumor_bags:
+        candidate = sampler.sample()
+        if candidate is None:
+            print(
+                f"Warning: exhausted tumor sampling attempts for {slide_path.name}."
+            )
+            break
+        center_x, center_y, _ = candidate
+        prefix = f"patch_{bag_index}"
+        bag = generate_hierarchy(
+            slide,
+            center_x,
+            center_y,
+            list(target_mpps),
+            prefix,
+            out_dir,
+            base_mpp,
+            patch_size,
+            tissue_threshold,
+            background_threshold,
+        )
+        if not bag:
+            continue
+        bag_node, tiles = bag
+        bag_node.update(
+            {
+                "label": tumor_label_name,
+                "label_id": tumor_label_id,
+                "center": [center_x, center_y],
+            }
+        )
+        bags.append(bag_node)
+        _record_patch_rows(
+            patch_rows,
+            tiles,
+            patient_id,
+            slide_path,
+            bag_index,
+            tumor_label_name,
+            tumor_label_id,
+        )
+        bag_index += 1
+        collected_tumor += 1
+
+    collected_normal = 0
+    max_attempts = max(4000, normal_bags * 50)
+    attempts = 0
+    while collected_normal < normal_bags and attempts < max_attempts:
+        attempts += 1
+        candidate = _sample_negative_center(
+            width,
+            height,
+            margin_int,
+            margin,
+            tumor_polygons,
+        )
+        if candidate is None:
+            break
+        center_x, center_y = candidate
+        if sampler is not None and _intersects_polygons(center_x, center_y, margin, tumor_polygons):
+            continue
+        prefix = f"patch_{bag_index}"
+        bag = generate_hierarchy(
+            slide,
+            center_x,
+            center_y,
+            list(target_mpps),
+            prefix,
+            out_dir,
+            base_mpp,
+            patch_size,
+            tissue_threshold,
+            background_threshold,
+        )
+        if not bag:
+            continue
+        bag_node, tiles = bag
+        bag_node.update(
+            {
+                "label": normal_label_name,
+                "label_id": normal_label_id,
+                "center": [center_x, center_y],
+            }
+        )
+        bags.append(bag_node)
+        _record_patch_rows(
+            patch_rows,
+            tiles,
+            patient_id,
+            slide_path,
+            bag_index,
+            normal_label_name,
+            normal_label_id,
+        )
+        bag_index += 1
+        collected_normal += 1
+
+    if collected_tumor < tumor_bags:
+        print(
+            f"Warning: collected {collected_tumor} tumor bags (requested {tumor_bags}) "
+            f"for {slide_path.name}."
+        )
+    if collected_normal < normal_bags:
+        print(
+            f"Warning: collected {collected_normal} normal bags (requested {normal_bags}) "
+            f"for {slide_path.name}."
+        )
+
+    with open(out_dir / "bags.json", "w") as f:
+        json.dump(bags, f, indent=2)
+
+    slide.close()
+    return bags, patch_rows
+
+
+def _write_manifest(csv_path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    rows = list(rows)
+    if not rows:
+        return
+    fieldnames = [
+        "patient_id",
+        "pathology_id",
+        "subtype",
+        "labels",
+        "resolved_path",
+        "slide_stem",
+        "bag_index",
+        "bag_label",
+        "bag_label_id",
+        "patch_id",
+        "patch_file",
+        "patch_path",
+        "patch_scale",
+    ]
+    with csv_path.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wsi_root", type=Path, help="Slide file or directory containing Camelyon WSIs")
+    parser.add_argument("output_dir", type=Path, help="Directory where patches and metadata will be stored")
+    parser.add_argument(
+        "--annotation-dir",
+        type=Path,
+        default=None,
+        help="Directory (or single XML file) containing Camelyon tumor annotations",
+    )
+    parser.add_argument("--tumor-bags", type=int, default=20, help="Number of tumor-centered bags to collect per slide")
+    parser.add_argument(
+        "--normal-bags",
+        type=int,
+        default=20,
+        help="Number of normal (non-tumor) bags to collect per slide",
+    )
+    parser.add_argument(
+        "--magnifications",
+        type=float,
+        nargs="+",
+        default=[2.0, 1.0, 0.5, 0.25],
+        help="Requested microns-per-pixel chain (coarse to fine)",
+    )
+    parser.add_argument("--patch-size", type=int, default=512, help="Output patch size in pixels")
+    parser.add_argument("--tissue-threshold", type=float, default=0.75, help="Minimum tissue fraction required to keep a patch")
+    parser.add_argument(
+        "--background-threshold",
+        type=int,
+        default=220,
+        help="Grayscale threshold that separates background from tissue",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used for reproducible sampling",
+    )
+
+    args = parser.parse_args()
+
+    slides = gather_slides(args.wsi_root)
+    if not slides:
+        raise SystemExit(f"No whole-slide images found under {args.wsi_root}")
+
+    output_dir: Path = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    annotation_root = args.annotation_dir
+    label_encoder = ValueLabelEncoder({"normal": (0, "Normal"), "tumor": (1, "Tumor")})
+
+    all_rows: List[Dict[str, str]] = []
+    for index, slide_path in enumerate(sorted(slides)):
+        print(f"Processing {slide_path}")
+        annotation_path = locate_annotation_file(slide_path, annotation_root)
+        tumor_polygons: List[AnnotationRegion] = []
+        if annotation_path is not None:
+            tumor_polygons = parse_camelyon_xml(annotation_path)
+            if not tumor_polygons:
+                print(
+                    f"Warning: annotation file {annotation_path} does not contain any tumor polygons."
+                )
+        else:
+            print(f"Warning: no annotation XML found for {slide_path.name}; treating slide as normal.")
+
+        _, patch_rows = sample_camelyon_slide(
+            slide_path,
+            output_dir,
+            tumor_polygons,
+            args.tumor_bags,
+            args.normal_bags,
+            args.seed + index,
+            args.magnifications,
+            args.patch_size,
+            args.tissue_threshold,
+            args.background_threshold,
+            label_encoder,
+        )
+        all_rows.extend(patch_rows)
+
+    manifest_path = output_dir / "patches.csv"
+    _write_manifest(manifest_path, all_rows)
+    print(f"Wrote patch manifest with {len(all_rows)} rows to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -190,14 +190,59 @@ def _unique_paths(paths: Sequence[Path]) -> List[Path]:
     return unique
 
 
+def index_annotation_files(
+    annotation_root: Optional[Path],
+) -> Dict[str, List[Path]]:
+    """Return a lookup table for annotation XMLs keyed by lowercase names."""
+
+    lookup: Dict[str, List[Path]] = defaultdict(list)
+
+    def _register(key: str, path: Path) -> None:
+        entries = lookup[key]
+        if path in entries:
+            return
+        if entries:
+            print(
+                "Warning: multiple annotation files map to key '"
+                f"{key}' (including {entries[0]} and {path})."
+            )
+        entries.append(path)
+
+    if annotation_root is None:
+        return lookup
+
+    if annotation_root.is_file():
+        key_stem = annotation_root.stem.lower()
+        key_name = annotation_root.name.lower()
+        _register(key_stem, annotation_root)
+        _register(key_name, annotation_root)
+        return lookup
+
+    if annotation_root.is_dir():
+        for xml_path in annotation_root.rglob("*.xml"):
+            key_stem = xml_path.stem.lower()
+            key_name = xml_path.name.lower()
+            _register(key_stem, xml_path)
+            _register(key_name, xml_path)
+
+    return lookup
+
+
 def load_slide_polygons(
     slide_path: Path,
     annotation_root: Optional[Path],
+    annotation_lookup: Optional[Dict[str, List[Path]]] = None,
 ) -> List[List[Tuple[float, float]]]:
     """Return polygons for ``slide_path`` if an annotation XML is available."""
 
     candidates: List[Path] = []
-    if annotation_root is not None:
+    normalized_keys = {slide_path.stem.lower(), slide_path.name.lower()}
+
+    if annotation_lookup:
+        for key in normalized_keys:
+            candidates.extend(annotation_lookup.get(key, []))
+
+    if annotation_root is not None and not candidates:
         if annotation_root.is_file():
             candidates.append(annotation_root)
         elif annotation_root.is_dir():
@@ -209,11 +254,19 @@ def load_slide_polygons(
                     annotation_root / f"{slide_path.stem.lower()}.xml",
                 ]
             )
-    candidates.append(slide_path.with_suffix(".xml"))
 
-    for candidate in _unique_paths(candidates):
+    annotation_candidates = _unique_paths(candidates)
+    candidate_keys = {path.resolve() for path in annotation_candidates if path.exists()}
+
+    fallback_candidate = slide_path.with_suffix(".xml")
+    combined_candidates = annotation_candidates + [fallback_candidate]
+
+    matched_annotation = False
+    for candidate in _unique_paths(combined_candidates):
         if not candidate.exists() or not candidate.is_file():
             continue
+        if candidate.resolve() in candidate_keys:
+            matched_annotation = True
         polygons = parse_aperio_xml(candidate)
         if polygons:
             return polygons
@@ -222,6 +275,13 @@ def load_slide_polygons(
                 f"Warning: annotation file {candidate} does not contain "
                 "any polygon regions."
             )
+
+    if annotation_root is not None and annotation_candidates and not matched_annotation:
+        print(
+            "Warning: no matching annotation XML found for "
+            f"{slide_path.name} in {annotation_root}."
+        )
+
     return []
 
 
@@ -661,6 +721,7 @@ def main() -> None:
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
     annotation_root = resolve_annotation_root(args.annotation_dir)
+    annotation_lookup = index_annotation_files(annotation_root)
 
     if args.metadata_csv is not None:
         metadata_rows, fieldnames = load_metadata_table(args.metadata_csv)
@@ -684,6 +745,7 @@ def main() -> None:
             annotation_polygons = load_slide_polygons(
                 slide_path,
                 annotation_root,
+                annotation_lookup,
             )
             bags_collected = process_wsi(
                 slide_path,
@@ -761,6 +823,7 @@ def main() -> None:
             annotation_polygons = load_slide_polygons(
                 slide_path,
                 annotation_root,
+                annotation_lookup,
             )
             process_wsi(
                 slide_path,

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -226,9 +226,16 @@ def parse_aperio_xml(xml_path: Path) -> List[AnnotationRegion]:
                 for attribute in attributes.findall("Attribute"):
                     name = attribute.get("Name") or attribute.get("name")
                     attr_value = attribute.get("Value") or attribute.get("value")
-                    if name and name.lower() == "value" and attr_value is not None:
-                        value = attr_value.strip()
+                    if attr_value is None:
+                        continue
+                    attr_value = attr_value.strip()
+                    if not attr_value:
+                        continue
+                    if name and name.lower() == "value":
+                        value = attr_value
                         break
+                    if value is None:
+                        value = attr_value
             polygons.append(AnnotationRegion(points=points, value=value))
     return polygons
 

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -71,26 +71,43 @@ class ValueLabelEncoder:
         "benign": (1, "Benign"),
         "in situ carcinoma": (2, "in situ carcinoma"),
         "carcinoma in situ": (2, "in situ carcinoma"),
+        "carcinoma in-situ": (2, "in situ carcinoma"),
+        "in-situ carcinoma": (2, "in situ carcinoma"),
+        "in situ": (2, "in situ carcinoma"),
         "situ": (2, "in situ carcinoma"),
+        "carcinoma situ": (2, "in situ carcinoma"),
         "invasive carcinoma": (3, "Invasive carcinoma"),
+        "carcinoma invasive": (3, "Invasive carcinoma"),
     }
+
+    @staticmethod
+    def _normalize(value: str) -> str:
+        normalized = value.lower().replace("-", " ")
+        normalized = " ".join(normalized.split())
+        return normalized
 
     def __init__(
         self, mapping: Optional[Dict[str, Tuple[int, str] | int]] = None
     ) -> None:
         source = mapping or self.DEFAULT_MAPPING
         processed: Dict[str, Tuple[int, str]] = {}
+        token_map: Dict[Tuple[str, ...], Tuple[int, str]] = {}
         for key, value in source.items():
             if isinstance(value, tuple):
                 label_id, canonical = value
             else:
                 label_id = value
                 canonical = key
-            processed[key.lower()] = (label_id, canonical)
+            norm_key = self._normalize(key)
+            processed[norm_key] = (label_id, canonical)
+            tokens = tuple(sorted(norm_key.split()))
+            if tokens and tokens not in token_map:
+                token_map[tokens] = (label_id, canonical)
         self._mapping = processed
+        self._token_mapping = token_map
 
     def encode(self, value: str) -> Tuple[int, str]:
-        key = value.strip().lower()
+        key = self._normalize(value.strip())
         if not key:
             raise ValueError("Cannot encode an empty annotation value")
 
@@ -102,6 +119,12 @@ class ValueLabelEncoder:
             situ = self._mapping.get("in situ carcinoma")
             if situ is not None:
                 return situ
+
+        tokens = tuple(sorted(key.split()))
+        if tokens:
+            match = self._token_mapping.get(tokens)
+            if match is not None:
+                return match
 
         for candidate_key, encoded in self._mapping.items():
             if candidate_key in key or key in candidate_key:

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -69,8 +69,8 @@ class ValueLabelEncoder:
     DEFAULT_MAPPING = {
         "normal": (0, "Normal"),
         "benign": (1, "Benign"),
-        "in situ carcinoma": (2, "in situ carcinoma"),
-        "carcinoma in situ": (2, "in situ carcinoma"),
+        "in situ carcinoma": (2, "In situ carcinoma"),
+        "carcinoma in situ": (2, "In situ carcinoma"),
         "invasive carcinoma": (3, "Invasive carcinoma"),
     }
 

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -92,12 +92,24 @@ class ValueLabelEncoder:
         key = value.strip().lower()
         if not key:
             raise ValueError("Cannot encode an empty annotation value")
-        if key not in self._mapping:
-            raise KeyError(
-                f"Annotation value '{value}' does not match any known subtype "
-                f"labels ({', '.join(sorted(self._mapping))})."
-            )
-        return self._mapping[key]
+
+        direct = self._mapping.get(key)
+        if direct is not None:
+            return direct
+
+        if "situ" in key:
+            situ = self._mapping.get("in situ carcinoma")
+            if situ is not None:
+                return situ
+
+        for candidate_key, encoded in self._mapping.items():
+            if candidate_key in key or key in candidate_key:
+                return encoded
+
+        raise KeyError(
+            f"Annotation value '{value}' does not match any known subtype "
+            f"labels ({', '.join(sorted(self._mapping))})."
+        )
 
 
 def polygon_area(points: Sequence[Tuple[float, float]]) -> float:

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -45,6 +45,37 @@ from PIL import Image
 import numpy as np
 
 
+@dataclass
+class AnnotationRegion:
+    """Polygonal region extracted from an Aperio XML annotation."""
+
+    points: List[Tuple[float, float]]
+    value: Optional[str] = None
+
+
+@dataclass
+class PatchTile:
+    """Metadata describing a saved patch tile."""
+
+    patch_id: str
+    patch_file: str
+    patch_path: Path
+    scale_suffix: str
+
+
+class ValueLabelEncoder:
+    """Assign deterministic integer labels to string values."""
+
+    def __init__(self) -> None:
+        self._mapping: Dict[str, int] = {}
+
+    def encode(self, value: str) -> int:
+        key = value.strip()
+        if key not in self._mapping:
+            self._mapping[key] = len(self._mapping)
+        return self._mapping[key]
+
+
 def polygon_area(points: Sequence[Tuple[float, float]]) -> float:
     """Return the absolute area of a polygon described by ``points``."""
 
@@ -93,14 +124,15 @@ class PolygonSampler:
 
     def __init__(
         self,
-        polygons: Sequence[Sequence[Tuple[float, float]]],
+        polygons: Sequence[AnnotationRegion],
         margin: float,
         slide_width: int,
         slide_height: int,
     ) -> None:
         self._margin = margin
         entries = []
-        for poly in polygons:
+        for region in polygons:
+            poly = region.points
             if len(poly) < 3:
                 continue
             xs = [p[0] for p in poly]
@@ -119,6 +151,7 @@ class PolygonSampler:
                     "polygon": list(poly),
                     "area": area,
                     "bounds": (min_x, max_x, min_y, max_y),
+                    "region": region,
                 }
             )
         self._entries = entries
@@ -127,7 +160,9 @@ class PolygonSampler:
     def is_available(self) -> bool:
         return bool(self._entries)
 
-    def sample(self, max_attempts: int = 2000) -> Optional[Tuple[int, int]]:
+    def sample(
+        self, max_attempts: int = 2000
+    ) -> Optional[Tuple[int, int, AnnotationRegion]]:
         if not self._entries:
             return None
         for _ in range(max_attempts):
@@ -142,12 +177,12 @@ class PolygonSampler:
                 continue
             if not _corners_inside(x, y, self._margin, polygon):
                 continue
-            return int(round(x)), int(round(y))
+            return int(round(x)), int(round(y)), entry["region"]
         return None
 
 
-def parse_aperio_xml(xml_path: Path) -> List[List[Tuple[float, float]]]:
-    """Parse an Aperio annotation XML file into polygons."""
+def parse_aperio_xml(xml_path: Path) -> List[AnnotationRegion]:
+    """Parse an Aperio annotation XML file into annotated regions."""
 
     try:
         tree = ET.parse(xml_path)
@@ -156,7 +191,7 @@ def parse_aperio_xml(xml_path: Path) -> List[List[Tuple[float, float]]]:
         return []
 
     root = tree.getroot()
-    polygons: List[List[Tuple[float, float]]] = []
+    polygons: List[AnnotationRegion] = []
     for region in root.findall(".//Region"):
         vertices = region.find("Vertices")
         if vertices is None:
@@ -172,7 +207,16 @@ def parse_aperio_xml(xml_path: Path) -> List[List[Tuple[float, float]]]:
             except ValueError:
                 continue
         if len(points) >= 3:
-            polygons.append(points)
+            value: Optional[str] = None
+            attributes = region.find("Attributes")
+            if attributes is not None:
+                for attribute in attributes.findall("Attribute"):
+                    name = attribute.get("Name") or attribute.get("name")
+                    attr_value = attribute.get("Value") or attribute.get("value")
+                    if name and name.lower() == "value" and attr_value is not None:
+                        value = attr_value.strip()
+                        break
+            polygons.append(AnnotationRegion(points=points, value=value))
     return polygons
 
 
@@ -232,7 +276,7 @@ def load_slide_polygons(
     slide_path: Path,
     annotation_root: Optional[Path],
     annotation_lookup: Optional[Dict[str, List[Path]]] = None,
-) -> List[List[Tuple[float, float]]]:
+) -> List[AnnotationRegion]:
     """Return polygons for ``slide_path`` if an annotation XML is available."""
 
     candidates: List[Path] = []
@@ -354,7 +398,7 @@ def generate_hierarchy(
     size: int = 512,
     tissue_threshold: float = 0.75,
     background_threshold: int = 220,
-) -> Optional[Dict[str, object]]:
+) -> Optional[Tuple[Dict[str, object], List[PatchTile]]]:
     """Generate a chain of patches centered at ``(center_x, center_y)``.
 
     The first entry in ``mpps`` corresponds to the coarsest magnification
@@ -386,6 +430,12 @@ def generate_hierarchy(
     if saved_path is None:
         return None
 
+    tile = PatchTile(
+        patch_id=patch_id,
+        patch_file=out_path.name,
+        patch_path=saved_path,
+        scale_suffix=suffix,
+    )
     node: Dict[str, object] = {"id": patch_id, "file": out_path.name, "children": []}
     if len(mpps) > 1:
         child = generate_hierarchy(
@@ -406,8 +456,19 @@ def generate_hierarchy(
             except FileNotFoundError:
                 pass
             return None
-        node["children"].append(child)
-    return node
+        child_node, child_tiles = child
+        node["children"].append(child_node)
+        tiles = [tile] + child_tiles
+    else:
+        tiles = [tile]
+    return node, tiles
+
+
+def _generate_patient_id(slide_path: Path) -> str:
+    """Return a deterministic pseudo-random identifier for ``slide_path``."""
+
+    seed = abs(hash(slide_path.stem.lower())) % 10**12
+    return f"{seed:012d}"
 
 
 def process_wsi(
@@ -417,8 +478,9 @@ def process_wsi(
     seed: int = 0,
     tissue_threshold: float = 0.75,
     background_threshold: int = 220,
-    polygons: Optional[List[List[Tuple[float, float]]]] = None,
-) -> int:
+    polygons: Optional[List[AnnotationRegion]] = None,
+    label_encoder: Optional[ValueLabelEncoder] = None,
+) -> Tuple[int, List[Dict[str, str]]]:
     """Process a single WSI and generate multi-scale patch bags.
 
     Returns the number of patch bags successfully collected.
@@ -452,6 +514,8 @@ def process_wsi(
             sampler = None
 
     bags = []
+    patch_rows: List[Dict[str, str]] = []
+    patient_id = _generate_patient_id(slide_path)
     i = 0
     attempts = 0
     max_attempts = num_parents * 20 if num_parents > 0 else 0
@@ -465,10 +529,11 @@ def process_wsi(
                     f"annotations for {slide_path.name}."
                 )
                 break
-            center_x, center_y = candidate
+            center_x, center_y, selected_region = candidate
         else:
             center_x = random.randint(margin_int, max_cx)
             center_y = random.randint(margin_int, max_cy)
+            selected_region = None
         prefix = f"patch_{i}"
         bag = generate_hierarchy(
             slide,
@@ -483,7 +548,30 @@ def process_wsi(
             background_threshold,
         )
         if bag:
-            bags.append(bag)
+            bag_node, tiles = bag
+            bags.append(bag_node)
+            region_value = selected_region.value.strip() if selected_region and selected_region.value else ""
+            if region_value and label_encoder is not None:
+                label_id = label_encoder.encode(region_value)
+                label_str = str(label_id)
+            else:
+                label_str = ""
+            for tile in tiles:
+                patch_rows.append(
+                    {
+                        "patient_id": patient_id,
+                        "pathology_id": slide_path.name,
+                        "subtype": region_value,
+                        "labels": label_str,
+                        "resolved_path": str(slide_path),
+                        "slide_stem": slide_path.stem,
+                        "bag_index": str(i),
+                        "patch_id": tile.patch_id,
+                        "patch_file": tile.patch_file,
+                        "patch_path": str(tile.patch_path),
+                        "patch_scale": tile.scale_suffix,
+                    }
+                )
             i += 1
 
     if i < num_parents:
@@ -491,13 +579,14 @@ def process_wsi(
             f"Warning: only collected {i} patch bags (requested {num_parents}) "
             f"for {slide_path.name}."
         )
+        patch_rows = []
 
     with open(out_dir / "bags.json", "w") as f:
         json.dump(bags, f, indent=2)
 
     slide.close()
 
-    return len(bags)
+    return len(bags), patch_rows
 
 
 def gather_slides(wsi_root: Path) -> List[Path]:
@@ -722,6 +811,8 @@ def main() -> None:
     args.out_dir.mkdir(parents=True, exist_ok=True)
     annotation_root = resolve_annotation_root(args.annotation_dir)
     annotation_lookup = index_annotation_files(annotation_root)
+    label_encoder = ValueLabelEncoder()
+    all_patch_rows: List[Dict[str, str]] = []
 
     if args.metadata_csv is not None:
         metadata_rows, fieldnames = load_metadata_table(args.metadata_csv)
@@ -747,7 +838,7 @@ def main() -> None:
                 annotation_root,
                 annotation_lookup,
             )
-            bags_collected = process_wsi(
+            bag_count, patch_rows = process_wsi(
                 slide_path,
                 args.out_dir,
                 num_parents=args.num_parents,
@@ -755,8 +846,9 @@ def main() -> None:
                 tissue_threshold=args.tissue_threshold,
                 background_threshold=args.background_threshold,
                 polygons=annotation_polygons,
+                label_encoder=label_encoder,
             )
-            if bags_collected < args.num_parents:
+            if bag_count < args.num_parents:
                 slide_out_dir = args.out_dir / slide_path.stem
                 if slide_out_dir.exists():
                     shutil.rmtree(slide_out_dir, ignore_errors=True)
@@ -764,12 +856,13 @@ def main() -> None:
                 print(
                     f"Scheduling an additional slide for subtype '{subtype}' "
                     f"because {slide_path.name} ({reason}) yielded "
-                    f"{bags_collected} patch bags."
+                    f"{bag_count} patch bags."
                 )
                 return False
 
             counts[subtype] += 1
             accepted_pairs.append(pair)
+            all_patch_rows.extend(patch_rows)
             return True
 
         for pair in selection.initial:
@@ -825,7 +918,7 @@ def main() -> None:
                 annotation_root,
                 annotation_lookup,
             )
-            process_wsi(
+            bag_count, patch_rows = process_wsi(
                 slide_path,
                 args.out_dir,
                 num_parents=args.num_parents,
@@ -833,7 +926,31 @@ def main() -> None:
                 tissue_threshold=args.tissue_threshold,
                 background_threshold=args.background_threshold,
                 polygons=annotation_polygons,
+                label_encoder=label_encoder,
             )
+            if bag_count >= args.num_parents or args.num_parents == 0:
+                all_patch_rows.extend(patch_rows)
+
+    if all_patch_rows:
+        patch_csv_path = args.out_dir / "patches.csv"
+        fieldnames = [
+            "patient_id",
+            "pathology_id",
+            "subtype",
+            "labels",
+            "resolved_path",
+            "slide_stem",
+            "bag_index",
+            "patch_id",
+            "patch_file",
+            "patch_path",
+            "patch_scale",
+        ]
+        with patch_csv_path.open("w", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in all_patch_rows:
+                writer.writerow(row)
 
 
 if __name__ == "__main__":

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -6,7 +6,10 @@ paper referenced as ``2504.18856v1``.
 
 For each WSI slide, the script randomly selects 20 seed locations.  At
 each location a hierarchy of patches is extracted that all share the
-same center but differ in magnification:
+same center but differ in magnification.  When Aperio XML annotations
+are provided via ``--annotation-dir``, seed locations are sampled only
+inside the annotated polygons so that all patches fall within the
+specified tissue region:
 
 * 5×  (2   µm/px)
 * 10× (1   µm/px)
@@ -34,11 +37,210 @@ from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from urllib.parse import unquote, urlparse
+import xml.etree.ElementTree as ET
 
 import openslide
 from PIL import Image
 import numpy as np
 
+
+def polygon_area(points: Sequence[Tuple[float, float]]) -> float:
+    """Return the absolute area of a polygon described by ``points``."""
+
+    area = 0.0
+    for (x0, y0), (x1, y1) in zip(points, points[1:]):
+        area += x0 * y1 - x1 * y0
+    if points:
+        x0, y0 = points[-1]
+        x1, y1 = points[0]
+        area += x0 * y1 - x1 * y0
+    return abs(area) * 0.5
+
+
+def point_in_polygon(x: float, y: float, polygon: Sequence[Tuple[float, float]]) -> bool:
+    """Return ``True`` if ``(x, y)`` lies inside ``polygon`` using ray casting."""
+
+    inside = False
+    n = len(polygon)
+    if n < 3:
+        return False
+    j = n - 1
+    for i in range(n):
+        xi, yi = polygon[i]
+        xj, yj = polygon[j]
+        if ((yi > y) != (yj > y)):
+            slope = (xj - xi) / (yj - yi) if (yj - yi) != 0 else float("inf")
+            x_intersect = slope * (y - yi) + xi if slope != float("inf") else xi
+            if x < x_intersect:
+                inside = not inside
+        j = i
+    return inside
+
+
+def _corners_inside(
+    x: float, y: float, margin: float, polygon: Sequence[Tuple[float, float]]
+) -> bool:
+    offsets = [(-margin, -margin), (-margin, margin), (margin, -margin), (margin, margin)]
+    for dx, dy in offsets:
+        if not point_in_polygon(x + dx, y + dy, polygon):
+            return False
+    return True
+
+
+class PolygonSampler:
+    """Randomly sample centers constrained to annotation polygons."""
+
+    def __init__(
+        self,
+        polygons: Sequence[Sequence[Tuple[float, float]]],
+        margin: float,
+        slide_width: int,
+        slide_height: int,
+    ) -> None:
+        self._margin = margin
+        entries = []
+        for poly in polygons:
+            if len(poly) < 3:
+                continue
+            xs = [p[0] for p in poly]
+            ys = [p[1] for p in poly]
+            min_x = max(min(xs) + margin, margin)
+            max_x = min(max(xs) - margin, slide_width - margin)
+            min_y = max(min(ys) + margin, margin)
+            max_y = min(max(ys) - margin, slide_height - margin)
+            if min_x >= max_x or min_y >= max_y:
+                continue
+            area = polygon_area(poly)
+            if area <= 0:
+                continue
+            entries.append(
+                {
+                    "polygon": list(poly),
+                    "area": area,
+                    "bounds": (min_x, max_x, min_y, max_y),
+                }
+            )
+        self._entries = entries
+        self._weights = [entry["area"] for entry in entries]
+
+    def is_available(self) -> bool:
+        return bool(self._entries)
+
+    def sample(self, max_attempts: int = 2000) -> Optional[Tuple[int, int]]:
+        if not self._entries:
+            return None
+        for _ in range(max_attempts):
+            entry = random.choices(self._entries, weights=self._weights, k=1)[0]
+            min_x, max_x, min_y, max_y = entry["bounds"]
+            if min_x >= max_x or min_y >= max_y:
+                continue
+            x = random.uniform(min_x, max_x)
+            y = random.uniform(min_y, max_y)
+            polygon = entry["polygon"]
+            if not point_in_polygon(x, y, polygon):
+                continue
+            if not _corners_inside(x, y, self._margin, polygon):
+                continue
+            return int(round(x)), int(round(y))
+        return None
+
+
+def parse_aperio_xml(xml_path: Path) -> List[List[Tuple[float, float]]]:
+    """Parse an Aperio annotation XML file into polygons."""
+
+    try:
+        tree = ET.parse(xml_path)
+    except ET.ParseError as exc:
+        print(f"Warning: failed to parse annotation file {xml_path}: {exc}")
+        return []
+
+    root = tree.getroot()
+    polygons: List[List[Tuple[float, float]]] = []
+    for region in root.findall(".//Region"):
+        vertices = region.find("Vertices")
+        if vertices is None:
+            continue
+        points: List[Tuple[float, float]] = []
+        for vertex in vertices.findall("Vertex"):
+            x_val = vertex.get("X")
+            y_val = vertex.get("Y")
+            if x_val is None or y_val is None:
+                continue
+            try:
+                points.append((float(x_val), float(y_val)))
+            except ValueError:
+                continue
+        if len(points) >= 3:
+            polygons.append(points)
+    return polygons
+
+
+def _unique_paths(paths: Sequence[Path]) -> List[Path]:
+    seen = set()
+    unique: List[Path] = []
+    for path in paths:
+        if not path:
+            continue
+        key = path.resolve()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def load_slide_polygons(
+    slide_path: Path,
+    annotation_root: Optional[Path],
+) -> List[List[Tuple[float, float]]]:
+    """Return polygons for ``slide_path`` if an annotation XML is available."""
+
+    candidates: List[Path] = []
+    if annotation_root is not None:
+        if annotation_root.is_file():
+            candidates.append(annotation_root)
+        elif annotation_root.is_dir():
+            candidates.extend(
+                [
+                    annotation_root / f"{slide_path.stem}.xml",
+                    annotation_root / f"{slide_path.name}.xml",
+                    annotation_root / f"{slide_path.stem.upper()}.xml",
+                    annotation_root / f"{slide_path.stem.lower()}.xml",
+                ]
+            )
+    candidates.append(slide_path.with_suffix(".xml"))
+
+    for candidate in _unique_paths(candidates):
+        if not candidate.exists() or not candidate.is_file():
+            continue
+        polygons = parse_aperio_xml(candidate)
+        if polygons:
+            return polygons
+        else:
+            print(
+                f"Warning: annotation file {candidate} does not contain "
+                "any polygon regions."
+            )
+    return []
+
+
+def resolve_annotation_root(annotation_root: Optional[Path]) -> Optional[Path]:
+    """Normalize ``annotation_root`` and resolve file:// URIs if necessary."""
+
+    if annotation_root is None:
+        return None
+
+    raw = str(annotation_root)
+    if raw.startswith("file:"):
+        parsed = urlparse(raw)
+        if parsed.scheme == "file":
+            decoded = unquote(parsed.path)
+            if decoded:
+                if decoded.startswith("/") and len(decoded) > 2 and decoded[2] == ":":
+                    decoded = decoded.lstrip("/")
+                return Path(decoded)
+    return annotation_root
 
 def compute_tissue_fraction(img: Image.Image, background_threshold: int = 220) -> float:
     """Return the fraction of pixels that are likely to be tissue.
@@ -155,6 +357,7 @@ def process_wsi(
     seed: int = 0,
     tissue_threshold: float = 0.75,
     background_threshold: int = 220,
+    polygons: Optional[List[List[Tuple[float, float]]]] = None,
 ) -> int:
     """Process a single WSI and generate multi-scale patch bags.
 
@@ -173,9 +376,20 @@ def process_wsi(
 
     # Compute bounds for sampling centers so that all magnifications fit
     parent_ds = target_mpps[0] / base_mpp
-    margin = int(size * parent_ds / 2)
-    max_cx = slide_width - margin
-    max_cy = slide_height - margin
+    margin = size * parent_ds / 2
+    margin_int = int(margin)
+    max_cx = slide_width - margin_int
+    max_cy = slide_height - margin_int
+
+    sampler: Optional[PolygonSampler] = None
+    if polygons:
+        sampler = PolygonSampler(polygons, margin, slide_width, slide_height)
+        if not sampler.is_available():
+            print(
+                "Warning: annotation polygons for "
+                f"{slide_path.name} are too small for sampling."
+            )
+            sampler = None
 
     bags = []
     i = 0
@@ -183,8 +397,18 @@ def process_wsi(
     max_attempts = num_parents * 20 if num_parents > 0 else 0
     while i < num_parents and (max_attempts == 0 or attempts < max_attempts):
         attempts += 1
-        center_x = random.randint(margin, max_cx)
-        center_y = random.randint(margin, max_cy)
+        if sampler is not None:
+            candidate = sampler.sample()
+            if candidate is None:
+                print(
+                    "Warning: unable to find more valid centers inside "
+                    f"annotations for {slide_path.name}."
+                )
+                break
+            center_x, center_y = candidate
+        else:
+            center_x = random.randint(margin_int, max_cx)
+            center_y = random.randint(margin_int, max_cy)
         prefix = f"patch_{i}"
         bag = generate_hierarchy(
             slide,
@@ -415,6 +639,14 @@ def main() -> None:
         help="Column in the metadata CSV that stores slide file names",
     )
     parser.add_argument(
+        "--annotation-dir",
+        type=Path,
+        help=(
+            "Directory or file containing Aperio-style XML annotations. "
+            "If provided, patches are sampled only from annotated regions."
+        ),
+    )
+    parser.add_argument(
         "--num-wsi",
         type=int,
         default=50,
@@ -428,6 +660,7 @@ def main() -> None:
         raise FileNotFoundError(f"No WSI files found at {args.wsi_dir}")
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
+    annotation_root = resolve_annotation_root(args.annotation_dir)
 
     if args.metadata_csv is not None:
         metadata_rows, fieldnames = load_metadata_table(args.metadata_csv)
@@ -448,6 +681,10 @@ def main() -> None:
             slide_path, row = pair
             subtype = row[args.metadata_subtype_column]
             print(f"Processing {slide_path}")
+            annotation_polygons = load_slide_polygons(
+                slide_path,
+                annotation_root,
+            )
             bags_collected = process_wsi(
                 slide_path,
                 args.out_dir,
@@ -455,6 +692,7 @@ def main() -> None:
                 seed=args.seed,
                 tissue_threshold=args.tissue_threshold,
                 background_threshold=args.background_threshold,
+                polygons=annotation_polygons,
             )
             if bags_collected < args.num_parents:
                 slide_out_dir = args.out_dir / slide_path.stem
@@ -520,6 +758,10 @@ def main() -> None:
     else:
         for slide_path in slides:
             print(f"Processing {slide_path}")
+            annotation_polygons = load_slide_polygons(
+                slide_path,
+                annotation_root,
+            )
             process_wsi(
                 slide_path,
                 args.out_dir,
@@ -527,6 +769,7 @@ def main() -> None:
                 seed=args.seed,
                 tissue_threshold=args.tissue_threshold,
                 background_threshold=args.background_threshold,
+                polygons=annotation_polygons,
             )
 
 

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -69,8 +69,8 @@ class ValueLabelEncoder:
     DEFAULT_MAPPING = {
         "normal": (0, "Normal"),
         "benign": (1, "Benign"),
-        "in situ carcinoma": (2, "In situ carcinoma"),
-        "carcinoma in situ": (2, "In situ carcinoma"),
+        "in situ carcinoma": (2, "Carcinoma in situ"),
+        "carcinoma in situ": (2, "Carcinoma in situ"),
         "invasive carcinoma": (3, "Invasive carcinoma"),
     }
 

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -260,6 +260,14 @@ def parse_aperio_xml(xml_path: Path) -> List[AnnotationRegion]:
                         break
                     if value is None:
                         value = attr_value
+
+            if value is None:
+                text_value = region.get("Text") or region.get("text")
+                if text_value:
+                    text_value = text_value.strip()
+                    if text_value:
+                        value = text_value
+
             polygons.append(AnnotationRegion(points=points, value=value))
     return polygons
 

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -71,6 +71,7 @@ class ValueLabelEncoder:
         "benign": 1,
         "in situ carcinoma": 2,
         "invasive carcinoma": 3,
+        "carcinoma in situ": 2,
     }
 
     def __init__(self, mapping: Optional[Dict[str, int]] = None) -> None:
@@ -570,13 +571,12 @@ def process_wsi(
         if bag:
             bag_node, tiles = bag
             bags.append(bag_node)
-            region_value = (
-                selected_region.value.strip()
-                if selected_region and selected_region.value
-                else ""
-            )
+            if selected_region and selected_region.value:
+                region_value = selected_region.value.strip() or "Normal"
+            else:
+                region_value = "Normal"
             label_str = ""
-            if region_value and label_encoder is not None:
+            if label_encoder is not None:
                 try:
                     label_id = label_encoder.encode(region_value)
                 except (KeyError, ValueError) as exc:

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -67,18 +67,28 @@ class ValueLabelEncoder:
     """Assign deterministic integer labels to known annotation values."""
 
     DEFAULT_MAPPING = {
-        "normal": 0,
-        "benign": 1,
-        "in situ carcinoma": 2,
-        "invasive carcinoma": 3,
-        "carcinoma in situ": 2,
+        "normal": (0, "Normal"),
+        "benign": (1, "Benign"),
+        "in situ carcinoma": (2, "in situ carcinoma"),
+        "carcinoma in situ": (2, "in situ carcinoma"),
+        "invasive carcinoma": (3, "Invasive carcinoma"),
     }
 
-    def __init__(self, mapping: Optional[Dict[str, int]] = None) -> None:
+    def __init__(
+        self, mapping: Optional[Dict[str, Tuple[int, str] | int]] = None
+    ) -> None:
         source = mapping or self.DEFAULT_MAPPING
-        self._mapping: Dict[str, int] = {k.lower(): v for k, v in source.items()}
+        processed: Dict[str, Tuple[int, str]] = {}
+        for key, value in source.items():
+            if isinstance(value, tuple):
+                label_id, canonical = value
+            else:
+                label_id = value
+                canonical = key
+            processed[key.lower()] = (label_id, canonical)
+        self._mapping = processed
 
-    def encode(self, value: str) -> int:
+    def encode(self, value: str) -> Tuple[int, str]:
         key = value.strip().lower()
         if not key:
             raise ValueError("Cannot encode an empty annotation value")
@@ -578,7 +588,7 @@ def process_wsi(
             label_str = ""
             if label_encoder is not None:
                 try:
-                    label_id = label_encoder.encode(region_value)
+                    label_id, canonical_value = label_encoder.encode(region_value)
                 except (KeyError, ValueError) as exc:
                     print(
                         "Warning:",
@@ -589,6 +599,7 @@ def process_wsi(
                     )
                 else:
                     label_str = str(label_id)
+                    region_value = canonical_value
             for tile in tiles:
                 patch_rows.append(
                     {

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -69,13 +69,13 @@ class ValueLabelEncoder:
     DEFAULT_MAPPING = {
         "normal": (0, "Normal"),
         "benign": (1, "Benign"),
-        "in situ carcinoma": (2, "in situ carcinoma"),
-        "carcinoma in situ": (2, "in situ carcinoma"),
-        "carcinoma in-situ": (2, "in situ carcinoma"),
-        "in-situ carcinoma": (2, "in situ carcinoma"),
-        "in situ": (2, "in situ carcinoma"),
-        "situ": (2, "in situ carcinoma"),
-        "carcinoma situ": (2, "in situ carcinoma"),
+        "in situ carcinoma": (2, "In situ carcinoma"),
+        "carcinoma in situ": (2, "In situ carcinoma"),
+        "carcinoma in-situ": (2, "In situ carcinoma"),
+        "in-situ carcinoma": (2, "In situ carcinoma"),
+        "in situ": (2, "In situ carcinoma"),
+        "situ": (2, "In situ carcinoma"),
+        "carcinoma situ": (2, "In situ carcinoma"),
         "invasive carcinoma": (3, "Invasive carcinoma"),
         "carcinoma invasive": (3, "Invasive carcinoma"),
     }
@@ -667,7 +667,6 @@ def process_wsi(
             f"Warning: only collected {i} patch bags (requested {num_parents}) "
             f"for {slide_path.name}."
         )
-        patch_rows = []
 
     with open(out_dir / "bags.json", "w") as f:
         json.dump(bags, f, indent=2)

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -64,15 +64,28 @@ class PatchTile:
 
 
 class ValueLabelEncoder:
-    """Assign deterministic integer labels to string values."""
+    """Assign deterministic integer labels to known annotation values."""
 
-    def __init__(self) -> None:
-        self._mapping: Dict[str, int] = {}
+    DEFAULT_MAPPING = {
+        "normal": 0,
+        "benign": 1,
+        "in situ carcinoma": 2,
+        "invasive carcinoma": 3,
+    }
+
+    def __init__(self, mapping: Optional[Dict[str, int]] = None) -> None:
+        source = mapping or self.DEFAULT_MAPPING
+        self._mapping: Dict[str, int] = {k.lower(): v for k, v in source.items()}
 
     def encode(self, value: str) -> int:
-        key = value.strip()
+        key = value.strip().lower()
+        if not key:
+            raise ValueError("Cannot encode an empty annotation value")
         if key not in self._mapping:
-            self._mapping[key] = len(self._mapping)
+            raise KeyError(
+                f"Annotation value '{value}' does not match any known subtype "
+                f"labels ({', '.join(sorted(self._mapping))})."
+            )
         return self._mapping[key]
 
 
@@ -550,12 +563,25 @@ def process_wsi(
         if bag:
             bag_node, tiles = bag
             bags.append(bag_node)
-            region_value = selected_region.value.strip() if selected_region and selected_region.value else ""
+            region_value = (
+                selected_region.value.strip()
+                if selected_region and selected_region.value
+                else ""
+            )
+            label_str = ""
             if region_value and label_encoder is not None:
-                label_id = label_encoder.encode(region_value)
-                label_str = str(label_id)
-            else:
-                label_str = ""
+                try:
+                    label_id = label_encoder.encode(region_value)
+                except (KeyError, ValueError) as exc:
+                    print(
+                        "Warning:",
+                        exc,
+                        "-- leaving label empty for",
+                        slide_path.name,
+                        f"(bag {i}).",
+                    )
+                else:
+                    label_str = str(label_id)
             for tile in tiles:
                 patch_rows.append(
                     {

--- a/scripts/sample_tcga_multiscale_patches.py
+++ b/scripts/sample_tcga_multiscale_patches.py
@@ -69,8 +69,9 @@ class ValueLabelEncoder:
     DEFAULT_MAPPING = {
         "normal": (0, "Normal"),
         "benign": (1, "Benign"),
-        "in situ carcinoma": (2, "Carcinoma in situ"),
-        "carcinoma in situ": (2, "Carcinoma in situ"),
+        "in situ carcinoma": (2, "in situ carcinoma"),
+        "carcinoma in situ": (2, "in situ carcinoma"),
+        "situ": (2, "in situ carcinoma"),
         "invasive carcinoma": (3, "Invasive carcinoma"),
     }
 


### PR DESCRIPTION
## Summary
- parse Aperio XML annotations and restrict patch sampling to annotated polygons when provided
- add a polygon-aware sampler that keeps multi-scale patches inside the annotated region and reports sampling issues
- support annotation directories or file:// URIs via the new `--annotation-dir` CLI option

## Testing
- python -m py_compile scripts/sample_tcga_multiscale_patches.py

------
https://chatgpt.com/codex/tasks/task_b_6900290e7a3483279d3d1d5564a6521a