### PR TITLE
Add mask-driven multiscale patch sampling script

### DIFF
--- a/scripts/plot_gabor_energy.py
+++ b/scripts/plot_gabor_energy.py
@@ -41,6 +41,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+try:  # Optional smoothing for clearer separation
+    from scipy.stats import gaussian_kde
+except Exception:  # pragma: no cover - optional dependency
+    gaussian_kde = None
+
 
 SUPPORTED_EXTS = {".csv", ".tsv", ".jsonl", ".json"}
 
@@ -140,6 +145,7 @@ def plot_energy(
     output: Path,
     bins: int = 40,
     alpha: float = 0.6,
+    kde: bool = True,
 ) -> None:
     if df.empty:
         raise ValueError("No data to plot after filtering.")
@@ -154,17 +160,39 @@ def plot_energy(
         ax = axes[idx // ncols][idx % ncols]
         subset = df[df["dataset"] == dataset]
         models = list(pd.unique(subset["model"]))
+
+        all_scores = subset["energy"].astype(float)
+        if all_scores.empty:
+            continue
+        xmin, xmax = all_scores.min(), all_scores.max()
+        margin = 0.05 * (xmax - xmin if xmax > xmin else 1.0)
+        bin_edges = np.linspace(xmin - margin, xmax + margin, bins + 1)
+
         for model in models:
             scores = subset[subset["model"] == model]["energy"].astype(float)
             label_row = subset[subset["model"] == model].iloc[0].to_dict()
+
+            color = ax._get_lines.get_next_color()
             ax.hist(
                 scores,
-                bins=bins,
+                bins=bin_edges,
                 density=True,
                 alpha=alpha,
                 label=_format_label(label_row),
-                edgecolor="none",
+                edgecolor="white",
+                linewidth=0.6,
+                histtype="stepfilled",
+                color=color,
             )
+
+            mean = float(scores.mean()) if len(scores) else 0.0
+            ax.axvline(mean, color=color, linestyle="--", linewidth=1.0, alpha=0.9)
+
+            if kde and gaussian_kde is not None and len(scores) > 1:
+                kde_fn = gaussian_kde(scores)
+                x_grid = np.linspace(bin_edges[0], bin_edges[-1], 400)
+                ax.plot(x_grid, kde_fn(x_grid), color=color, linewidth=1.6)
+
         ax.set_title(dataset)
         ax.set_xlabel("Energy Score")
         ax.set_ylabel("Frequency")
@@ -213,6 +241,12 @@ def parse_args() -> argparse.Namespace:
         help="Histogram alpha/opacity (default: 0.6).",
     )
     parser.add_argument(
+        "--no-kde",
+        dest="kde",
+        action="store_false",
+        help="Disable KDE overlay lines (enabled by default).",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         default=Path("gabor_energy.png"),
@@ -225,7 +259,7 @@ def main() -> None:
     args = parse_args()
     df = load_energy_tables(args.input)
     df = filter_and_order(df, args.datasets, args.models)
-    plot_energy(df, args.output, bins=args.bins, alpha=args.alpha)
+    plot_energy(df, args.output, bins=args.bins, alpha=args.alpha, kde=args.kde)
 
 
 if __name__ == "__main__":

--- a/scripts/plot_gabor_energy.py
+++ b/scripts/plot_gabor_energy.py
@@ -1,0 +1,232 @@
+"""Plot Gabor energy score histograms across datasets and models.
+
+This utility mirrors the reference style shown in the prompt: for each
+dataset, it overlays energy-score distributions from multiple models on the
+same axes. The script expects tabular inputs containing at least the columns
+``dataset``, ``model``, and ``energy``. An optional ``accuracy`` column can be
+used to annotate legend entries (``Model (acc:95.5%)``). When no input files
+are provided, the script falls back to a synthetic TCGA-like example so the
+command can run out-of-the-box.
+
+Example usage with a single CSV (comma-separated) containing all datasets::
+
+    python scripts/plot_gabor_energy.py \
+      --input energies.csv \
+      --datasets CIFAR10 Caltech-101 TCGA \
+      --models GoogLeNet "ResNet-50" "DenseNet-169" InceptionV3 \
+      --output gabor_energy.png
+
+Example usage with multiple CSV/TSV files (auto-detected by extension)::
+
+    python scripts/plot_gabor_energy.py \
+      --input tcga_scores.csv \
+      --input cifar_scores.tsv \
+      --output gabor_energy.png
+
+The script supports CSV, TSV, and JSON Lines (``.jsonl``) inputs. Each input
+file should contain one energy score per row. If ``--datasets`` or
+``--models`` are provided, they are used to filter and order the subplots and
+legend entries respectively.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+SUPPORTED_EXTS = {".csv", ".tsv", ".jsonl", ".json"}
+
+
+def _read_table(path: Path) -> pd.DataFrame:
+    suffix = path.suffix.lower()
+    if suffix not in SUPPORTED_EXTS:
+        raise ValueError(f"Unsupported input extension: {path}")
+
+    if suffix == ".csv":
+        return pd.read_csv(path)
+    if suffix == ".tsv":
+        return pd.read_csv(path, sep="\t")
+    if suffix in {".jsonl", ".json"}:
+        # Load JSON Lines if multiple objects; fall back to a JSON array.
+        with path.open("r") as f:
+            first_char = f.read(1)
+            f.seek(0)
+            if first_char == "{":
+                return pd.read_json(path, lines=True)
+            return pd.read_json(path)
+
+    raise ValueError(f"Unhandled extension: {path}")
+
+
+def _maybe_synthesize() -> pd.DataFrame:
+    """Create a synthetic TCGA example so the script can run standalone."""
+
+    rng = np.random.default_rng(0)
+    entries = []
+    datasets = ["TCGA"]
+    models = [
+        ("GoogLeNet", 95.5),
+        ("ResNet-34", 96.1),
+        ("DenseNet-169", 96.8),
+        ("InceptionV3", 92.8),
+    ]
+    for dataset in datasets:
+        for model, acc in models:
+            # Simulate slightly different energy distributions per model.
+            mean = 20 + (hash(model) % 5) * 0.5
+            sigma = 3.0 + (hash(model) % 3) * 0.4
+            scores = rng.normal(loc=mean, scale=sigma, size=600)
+            scores = np.clip(scores, 0, None)
+            for s in scores:
+                entries.append({
+                    "dataset": dataset,
+                    "model": model,
+                    "energy": float(s),
+                    "accuracy": acc,
+                })
+    return pd.DataFrame(entries)
+
+
+def _normalize_labels(df: pd.DataFrame) -> pd.DataFrame:
+    required = {"dataset", "model", "energy"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"Input is missing required columns: {sorted(missing)}")
+    return df
+
+
+def load_energy_tables(paths: Sequence[Path]) -> pd.DataFrame:
+    if not paths:
+        return _normalize_labels(_maybe_synthesize())
+
+    frames: List[pd.DataFrame] = []
+    for p in paths:
+        frames.append(_read_table(p))
+    return _normalize_labels(pd.concat(frames, ignore_index=True))
+
+
+def filter_and_order(
+    df: pd.DataFrame,
+    datasets: Optional[Sequence[str]],
+    models: Optional[Sequence[str]],
+) -> pd.DataFrame:
+    filtered = df
+    if datasets:
+        filtered = filtered[filtered["dataset"].isin(datasets)]
+        filtered["dataset"] = pd.Categorical(filtered["dataset"], categories=datasets, ordered=True)
+    if models:
+        filtered = filtered[filtered["model"].isin(models)]
+        filtered["model"] = pd.Categorical(filtered["model"], categories=models, ordered=True)
+    return filtered
+
+
+def _format_label(row: Mapping[str, object]) -> str:
+    acc = row.get("accuracy")
+    if acc is None or (isinstance(acc, float) and math.isnan(acc)):
+        return str(row["model"])
+    return f"{row['model']} (acc:{float(acc):.1f}%)"
+
+
+def plot_energy(
+    df: pd.DataFrame,
+    output: Path,
+    bins: int = 40,
+    alpha: float = 0.6,
+) -> None:
+    if df.empty:
+        raise ValueError("No data to plot after filtering.")
+
+    datasets = list(pd.unique(df["dataset"]))
+    ncols = min(2, len(datasets))
+    nrows = int(math.ceil(len(datasets) / ncols))
+
+    fig, axes = plt.subplots(nrows=nrows, ncols=ncols, figsize=(6 * ncols, 4 * nrows), squeeze=False)
+
+    for idx, dataset in enumerate(datasets):
+        ax = axes[idx // ncols][idx % ncols]
+        subset = df[df["dataset"] == dataset]
+        models = list(pd.unique(subset["model"]))
+        for model in models:
+            scores = subset[subset["model"] == model]["energy"].astype(float)
+            label_row = subset[subset["model"] == model].iloc[0].to_dict()
+            ax.hist(
+                scores,
+                bins=bins,
+                density=True,
+                alpha=alpha,
+                label=_format_label(label_row),
+                edgecolor="none",
+            )
+        ax.set_title(dataset)
+        ax.set_xlabel("Energy Score")
+        ax.set_ylabel("Frequency")
+        ax.legend()
+        ax.grid(alpha=0.2, linestyle="--")
+
+    # Hide any unused subplots
+    for j in range(len(datasets), nrows * ncols):
+        axes[j // ncols][j % ncols].axis("off")
+
+    fig.tight_layout()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output, dpi=200)
+    print(f"Saved plot to {output}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        action="append",
+        type=Path,
+        default=[],
+        help="Path(s) to CSV/TSV/JSONL files with columns dataset, model, energy, accuracy (optional).",
+    )
+    parser.add_argument(
+        "--datasets",
+        nargs="*",
+        help="Datasets to include and order in the plot (e.g., CIFAR10 Caltech-101 TCGA).",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="*",
+        help="Models to include and order (e.g., GoogLeNet ResNet-34 DenseNet-169 InceptionV3).",
+    )
+    parser.add_argument(
+        "--bins",
+        type=int,
+        default=40,
+        help="Number of histogram bins (default: 40).",
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.6,
+        help="Histogram alpha/opacity (default: 0.6).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("gabor_energy.png"),
+        help="Output image path (default: gabor_energy.png).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    df = load_energy_tables(args.input)
+    df = filter_and_order(df, args.datasets, args.models)
+    plot_energy(df, args.output, bins=args.bins, alpha=args.alpha)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_agcc_multiscale_patches.py
+++ b/scripts/sample_agcc_multiscale_patches.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Sample multiscale patches for the AGCC dataset with per-class mask folders.
+
+Each AGCC whole-slide image (e.g., ``Subset1_Test_1.tiff``) has a sibling mask
+folder with the same stem (``Subset1_Test_1``) that contains class-specific mask
+files such as ``G3_Mask.tiff``, ``G4_Mask.tiff``, ``Normal_Mask.tiff``, and
+``Stroma_Mask.tiff``. This script assembles those masks into a label map, then
+samples positive bags per class and negative bags from background, mirroring the
+multi-scale pipeline used by ``sample_camelyon_multiscale_patches.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+from PIL import Image
+
+# Disable PIL's decompression bomb check for very large whole-slide images.
+Image.MAX_IMAGE_PIXELS = None
+
+from sample_tcga_multiscale_patches import PatchTile, ValueLabelEncoder, compute_tissue_fraction
+
+
+@dataclass
+class BagResult:
+    """Stores the hierarchy node and associated tiles for a sampled bag."""
+
+    node: Dict[str, object]
+    tiles: List[PatchTile]
+
+
+SUPPORTED_IMAGE_EXTS = (".tif", ".tiff")
+SUPPORTED_MASK_EXTS = (".tif", ".tiff", ".png")
+
+CLASS_INFO = [
+    {"id": 0, "name": "Background", "abbr": "BKG"},
+    {"id": 1, "name": "G3", "abbr": "G3"},
+    {"id": 2, "name": "G4", "abbr": "G4"},
+    {"id": 3, "name": "Normal", "abbr": "NOR"},
+    {"id": 4, "name": "Stroma", "abbr": "STR"},
+]
+
+# Expected mask file stems per class (case-insensitive).
+CLASS_MASK_STEMS = {
+    "G3": "G3_Mask",
+    "G4": "G4_Mask",
+    "Normal": "Normal_Mask",
+    "Stroma": "Stroma_Mask",
+}
+
+
+def _ensure_output_dir(out_root: Path, image_path: Path) -> Path:
+    out_dir = out_root / image_path.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _gather_images(image_root: Path, image_exts: Sequence[str]) -> List[Path]:
+    return [
+        path
+        for ext in image_exts
+        for path in sorted(image_root.glob(f"**/*{ext}"))
+        if path.is_file()
+    ]
+
+
+def _load_image(path: Path) -> Image.Image:
+    return Image.open(path).convert("RGB")
+
+
+def _find_class_mask(mask_dir: Path, class_name: str, mask_exts: Sequence[str]) -> Optional[Path]:
+    stem = CLASS_MASK_STEMS.get(class_name)
+    if stem is None:
+        return None
+    lower_exts = [ext.lower() for ext in mask_exts]
+    for ext in lower_exts:
+        candidate = mask_dir / f"{stem}{ext}"
+        if candidate.exists():
+            return candidate
+        # Try case variations for robustness
+        alt = mask_dir / f"{stem.lower()}{ext}"
+        if alt.exists():
+            return alt
+    return None
+
+
+def _load_binary_mask(path: Path) -> np.ndarray:
+    mask = Image.open(path).convert("L")
+    return np.array(mask)
+
+
+def _build_label_map(mask_dir: Path, mask_exts: Sequence[str]) -> np.ndarray:
+    # Will be sized after first discovered mask; start empty.
+    label_map: Optional[np.ndarray] = None
+
+    for class_info in CLASS_INFO:
+        if class_info["id"] == 0:
+            continue
+        mask_path = _find_class_mask(mask_dir, class_info["name"], mask_exts)
+        if mask_path is None:
+            continue
+        mask = _load_binary_mask(mask_path)
+        if label_map is None:
+            label_map = np.zeros_like(mask, dtype=np.int16)
+        elif label_map.shape != mask.shape:
+            raise ValueError(
+                f"Mask {mask_path} has shape {mask.shape}, expected {label_map.shape} to match other masks in {mask_dir}"
+            )
+        positives = mask > 0
+        label_map[positives] = class_info["id"]
+
+    if label_map is None:
+        raise ValueError(f"No class masks found in {mask_dir}")
+
+    return label_map
+
+
+def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
+    if not scales:
+        return patch_size // 2
+    max_scale = max(scales) / scales[0]
+    margin = int(patch_size * max_scale / 2)
+    return max(1, margin)
+
+
+def _sample_centers(label_map: np.ndarray, count: int, margin: int, class_id: int) -> List[Tuple[int, int]]:
+    if count <= 0:
+        return []
+    coords = np.argwhere(label_map == class_id)
+    if len(coords) == 0:
+        return []
+    height, width = label_map.shape
+    valid = [
+        (int(x), int(y))
+        for y, x in coords
+        if margin <= x < width - margin and margin <= y < height - margin
+    ]
+    if not valid:
+        return []
+    random.shuffle(valid)
+    return valid[:count]
+
+
+def _extract_patch(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    patch_size: int,
+    scale_factor: float,
+    tissue_threshold: float,
+    background_threshold: int,
+    out_path: Path,
+) -> Optional[Path]:
+    window = max(1, int(round(patch_size * scale_factor)))
+    half = window // 2
+    left = center_x - half
+    top = center_y - half
+    right = left + window
+    bottom = top + window
+
+    if left < 0 or top < 0 or right > image.width or bottom > image.height:
+        return None
+
+    crop = image.crop((left, top, right, bottom))
+    if crop.size != (patch_size, patch_size):
+        crop = crop.resize((patch_size, patch_size), Image.BILINEAR)
+
+    tissue_fraction = compute_tissue_fraction(crop, background_threshold)
+    if tissue_fraction < tissue_threshold:
+        return None
+
+    crop.save(out_path)
+    return out_path
+
+
+def generate_hierarchy_from_image(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    scales: Sequence[float],
+    prefix: str,
+    out_dir: Path,
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+) -> Optional[BagResult]:
+    if not scales:
+        raise ValueError("At least one scale value must be provided")
+
+    root_tiles: List[PatchTile] = []
+    nodes: Dict[str, object] = {}
+
+    base_scale = float(scales[0])
+    parent: Optional[Dict[str, object]] = None
+
+    mag_map = {2.0: "5x", 1.0: "10x", 0.5: "20x", 0.25: "40x"}
+
+    for scale in scales:
+        if scale <= 0:
+            raise ValueError("Scale values must be positive")
+        window_factor = scale / base_scale
+        suffix = mag_map.get(scale, f"{scale:.2f}mpp")
+        patch_id = f"{prefix}_{suffix}"
+        out_path = out_dir / f"{patch_id}.png"
+
+        saved = _extract_patch(
+            image,
+            center_x,
+            center_y,
+            patch_size,
+            window_factor,
+            tissue_threshold,
+            background_threshold,
+            out_path,
+        )
+        if saved is None:
+            for tile in root_tiles:
+                try:
+                    tile.patch_path.unlink()
+                except FileNotFoundError:
+                    pass
+            return None
+
+        tile = PatchTile(
+            patch_id=patch_id,
+            patch_file=out_path.name,
+            patch_path=saved,
+            scale_suffix=suffix,
+        )
+        root_tiles.append(tile)
+
+        node: Dict[str, object] = {"id": patch_id, "file": out_path.name, "children": []}
+        if parent is not None:
+            parent.setdefault("children", []).append(node)
+        else:
+            nodes = node
+        parent = node
+
+    return BagResult(node=nodes, tiles=root_tiles)
+
+
+def _record_patch_rows(
+    rows: List[Dict[str, str]],
+    tiles: Iterable[PatchTile],
+    patient_id: str,
+    image_path: Path,
+    bag_index: int,
+    label_name: str,
+    label_id: int,
+) -> None:
+    for tile in tiles:
+        rows.append(
+            {
+                "patient_id": patient_id,
+                "pathology_id": image_path.name,
+                "subtype": label_name,
+                "labels": str(label_id),
+                "resolved_path": str(image_path),
+                "slide_stem": image_path.stem,
+                "bag_index": str(bag_index),
+                "bag_label": label_name,
+                "bag_label_id": str(label_id),
+                "patch_id": tile.patch_id,
+                "patch_file": tile.patch_file,
+                "patch_path": str(tile.patch_path),
+                "patch_scale": tile.scale_suffix,
+            }
+        )
+
+
+def _generate_patient_id(image_path: Path) -> str:
+    seed = abs(hash(image_path.stem.lower())) % 10**12
+    return f"{seed:012d}"
+
+
+def sample_image(
+    image_path: Path,
+    mask_root: Path,
+    out_root: Path,
+    positive_bags: int,
+    negative_bags: int,
+    seed: int,
+    scales: Sequence[float],
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+    label_encoder: ValueLabelEncoder,
+    mask_exts: Sequence[str],
+) -> Tuple[List[Dict[str, object]], List[Dict[str, str]]]:
+    random.seed(seed)
+
+    mask_dir = mask_root / image_path.stem
+    if not mask_dir.exists():
+        raise ValueError(f"Mask directory {mask_dir} does not exist for image {image_path.name}")
+
+    image = _load_image(image_path)
+    label_map = _build_label_map(mask_dir, mask_exts)
+    if label_map.shape[:2] != (image.height, image.width):
+        raise ValueError(
+            f"Masks under {mask_dir} do not match image dimensions for {image_path.name}: "
+            f"expected {(image.height, image.width)}, got {label_map.shape[:2]}"
+        )
+
+    out_dir = _ensure_output_dir(out_root, image_path)
+    margin = _compute_max_margin(patch_size, scales)
+
+    bags: List[Dict[str, object]] = []
+    patch_rows: List[Dict[str, str]] = []
+    patient_id = _generate_patient_id(image_path)
+    background_id = CLASS_INFO[0]["id"]
+
+    bag_index = 0
+    for class_info in CLASS_INFO:
+        class_id = class_info["id"]
+        class_name = class_info["name"]
+        if class_id == background_id:
+            continue
+        centers = _sample_centers(label_map, positive_bags, margin, class_id)
+        if not centers:
+            continue
+        label_id, label_name = label_encoder.encode(class_name)
+        for center_x, center_y in centers:
+            prefix = f"patch_{bag_index}"
+            bag = generate_hierarchy_from_image(
+                image,
+                center_x,
+                center_y,
+                list(scales),
+                prefix,
+                out_dir,
+                patch_size,
+                tissue_threshold,
+                background_threshold,
+            )
+            if not bag:
+                continue
+            bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+            bags.append(bag.node)
+            _record_patch_rows(
+                patch_rows,
+                bag.tiles,
+                patient_id,
+                image_path,
+                bag_index,
+                label_name,
+                label_id,
+            )
+            bag_index += 1
+
+    centers_background = _sample_centers(label_map, negative_bags, margin, background_id)
+    if centers_background:
+        label_id, label_name = label_encoder.encode(CLASS_INFO[0]["name"])
+        for center_x, center_y in centers_background:
+            prefix = f"patch_{bag_index}"
+            bag = generate_hierarchy_from_image(
+                image,
+                center_x,
+                center_y,
+                list(scales),
+                prefix,
+                out_dir,
+                patch_size,
+                tissue_threshold,
+                background_threshold,
+            )
+            if not bag:
+                continue
+            bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+            bags.append(bag.node)
+            _record_patch_rows(
+                patch_rows,
+                bag.tiles,
+                patient_id,
+                image_path,
+                bag_index,
+                label_name,
+                label_id,
+            )
+            bag_index += 1
+
+    bags_path = out_dir / "bags.json"
+    with bags_path.open("w", encoding="utf-8") as f:
+        json.dump(bags, f, indent=2)
+
+    return bags, patch_rows
+
+
+def _write_manifest(path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    rows = list(rows)
+    if not rows:
+        return
+    fieldnames = [
+        "patient_id",
+        "pathology_id",
+        "subtype",
+        "labels",
+        "resolved_path",
+        "slide_stem",
+        "bag_index",
+        "bag_label",
+        "bag_label_id",
+        "patch_id",
+        "patch_file",
+        "patch_path",
+        "patch_scale",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image_dir", type=Path, help="Root directory containing AGCC images (TIFF)")
+    parser.add_argument(
+        "mask_dir",
+        type=Path,
+        help="Root directory containing per-image mask folders (one folder per image stem)",
+    )
+    parser.add_argument("output_dir", type=Path, help="Directory where patches and manifests are written")
+    parser.add_argument(
+        "--positive-bags",
+        type=int,
+        default=5,
+        help="Number of bags to sample per annotated class (excluding background)",
+    )
+    parser.add_argument(
+        "--negative-bags", type=int, default=5, help="Number of background bags to sample per image"
+    )
+    parser.add_argument(
+        "--magnifications",
+        type=float,
+        nargs="+",
+        default=[2.0, 1.0, 0.5, 0.25],
+        help="Requested microns-per-pixel chain (coarse to fine)",
+    )
+    parser.add_argument("--patch-size", type=int, default=512, help="Output patch size in pixels")
+    parser.add_argument("--tissue-threshold", type=float, default=0.75, help="Minimum tissue fraction required to keep a patch")
+    parser.add_argument(
+        "--background-threshold",
+        type=int,
+        default=220,
+        help="Grayscale threshold that separates background from tissue",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used for reproducible sampling",
+    )
+    parser.add_argument(
+        "--image-exts",
+        nargs="+",
+        default=list(SUPPORTED_IMAGE_EXTS),
+        help="Image filename extensions to include (default: TIFF)",
+    )
+    parser.add_argument(
+        "--mask-exts",
+        nargs="+",
+        default=list(SUPPORTED_MASK_EXTS),
+        help="Mask filename extensions to search for inside each per-image folder",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    images = _gather_images(args.image_dir, args.image_exts)
+    if not images:
+        raise SystemExit(f"No images found under {args.image_dir} with extensions {args.image_exts}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    label_encoder = ValueLabelEncoder({info["name"].lower(): (info["id"], info["name"]) for info in CLASS_INFO})
+
+    all_rows: List[Dict[str, str]] = []
+    for index, image_path in enumerate(images):
+        try:
+            _, patch_rows = sample_image(
+                image_path,
+                args.mask_dir,
+                args.output_dir,
+                args.positive_bags,
+                args.negative_bags,
+                args.seed + index,
+                args.magnifications,
+                args.patch_size,
+                args.tissue_threshold,
+                args.background_threshold,
+                label_encoder,
+                args.mask_exts,
+            )
+        except ValueError as e:
+            print(f"Warning: skipping {image_path} due to error: {e}")
+            continue
+        all_rows.extend(patch_rows)
+
+    manifest_path = args.output_dir / "patches.csv"
+    _write_manifest(manifest_path, all_rows)
+    print(f"Wrote patch manifest with {len(all_rows)} rows to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_bncb_multiscale_patches.py
+++ b/scripts/sample_bncb_multiscale_patches.py
@@ -51,12 +51,7 @@ def _ensure_output_dir(out_root: Path, image_path: Path) -> Path:
 
 
 def _has_existing_patches(out_root: Path, image_path: Path) -> bool:
-    """Return True if patches for this image already exist.
-
-    We look for previously saved patch PNGs or a ``bags.json`` file in the
-    slide-specific output directory. When present, the slide is skipped to
-    avoid recomputing patches.
-    """
+    """Return True if patches for this image already exist."""
 
     out_dir = out_root / image_path.stem
     if not out_dir.exists():
@@ -66,6 +61,77 @@ def _has_existing_patches(out_root: Path, image_path: Path) -> bool:
         return True
 
     return any(out_dir.glob("*.png"))
+
+
+def _parse_bag_index(patch_id: str) -> Optional[int]:
+    parts = patch_id.split("_")
+    if len(parts) < 3 or parts[0] != "patch":
+        return None
+    try:
+        return int(parts[1])
+    except ValueError:
+        return None
+
+
+def _collect_nodes(node: Dict[str, object]) -> List[Dict[str, object]]:
+    nodes = [node]
+    for child in node.get("children", []) or []:
+        if isinstance(child, dict):
+            nodes.extend(_collect_nodes(child))
+    return nodes
+
+
+def _load_existing_patch_rows(
+    image_path: Path, out_root: Path, label_encoder: ValueLabelEncoder
+) -> List[Dict[str, str]]:
+    """Reconstruct manifest rows from a prior run if patches already exist."""
+
+    out_dir = out_root / image_path.stem
+    bags_path = out_dir / "bags.json"
+    if not bags_path.exists():
+        return []
+
+    patient_id = _generate_patient_id(image_path)
+    with bags_path.open("r", encoding="utf-8") as f:
+        bags = json.load(f)
+
+    rows: List[Dict[str, str]] = []
+    for bag in bags if isinstance(bags, list) else []:
+        if not isinstance(bag, dict):
+            continue
+        label_name = bag.get("label", "Unknown")
+        label_id = bag.get("label_id")
+        if label_id is None:
+            try:
+                label_id, _ = label_encoder.encode(label_name)
+            except KeyError:
+                label_id = CLASS_INFO[0]["id"]
+        bag_nodes = _collect_nodes(bag)
+        bag_index = None
+        for node in bag_nodes:
+            patch_id = str(node.get("id", ""))
+            bag_index = bag_index or _parse_bag_index(patch_id)
+            patch_file = str(node.get("file", ""))
+            if not patch_file:
+                continue
+            patch_scale = patch_id.split("_")[-1] if "_" in patch_id else ""
+            patch_rows = {
+                "patient_id": patient_id,
+                "pathology_id": image_path.name,
+                "subtype": label_name,
+                "labels": str(label_id),
+                "resolved_path": str(image_path),
+                "slide_stem": image_path.stem,
+                "bag_index": str(bag_index or 0),
+                "bag_label": label_name,
+                "bag_label_id": str(label_id),
+                "patch_id": patch_id,
+                "patch_file": patch_file,
+                "patch_path": str(out_dir / patch_file),
+                "patch_scale": patch_scale,
+            }
+            rows.append(patch_rows)
+    return rows
 
 
 def _gather_images(image_root: Path, image_exts: Sequence[str]) -> List[Path]:
@@ -344,7 +410,8 @@ def sample_image(
 
     if _has_existing_patches(out_root, image_path):
         print(f"Skipping {image_path.name}: patches already exist under {out_root / image_path.stem}")
-        return [], []
+        existing_rows = _load_existing_patch_rows(image_path, out_root, label_encoder)
+        return [], existing_rows
 
     image = _load_image(image_path)
     label_map = _load_label_map(annotation_path, (image.width, image.height))

--- a/scripts/sample_bncb_multiscale_patches.py
+++ b/scripts/sample_bncb_multiscale_patches.py
@@ -50,6 +50,24 @@ def _ensure_output_dir(out_root: Path, image_path: Path) -> Path:
     return out_dir
 
 
+def _has_existing_patches(out_root: Path, image_path: Path) -> bool:
+    """Return True if patches for this image already exist.
+
+    We look for previously saved patch PNGs or a ``bags.json`` file in the
+    slide-specific output directory. When present, the slide is skipped to
+    avoid recomputing patches.
+    """
+
+    out_dir = out_root / image_path.stem
+    if not out_dir.exists():
+        return False
+
+    if (out_dir / "bags.json").exists():
+        return True
+
+    return any(out_dir.glob("*.png"))
+
+
 def _gather_images(image_root: Path, image_exts: Sequence[str]) -> List[Path]:
     return [
         path
@@ -323,6 +341,10 @@ def sample_image(
             break
     if annotation_path is None:
         raise ValueError(f"No annotation JSON found for {image_path.name} under {annotation_dir}")
+
+    if _has_existing_patches(out_root, image_path):
+        print(f"Skipping {image_path.name}: patches already exist under {out_root / image_path.stem}")
+        return [], []
 
     image = _load_image(image_path)
     label_map = _load_label_map(annotation_path, (image.width, image.height))

--- a/scripts/sample_bncb_multiscale_patches.py
+++ b/scripts/sample_bncb_multiscale_patches.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Sample multiscale patches for the BNCB dataset using JSON polygon annotations.
+
+Each image (e.g., ``2.jpg``) has a sibling JSON file (``2.json``) containing
+polygon annotations for tumor regions. All annotated regions are considered
+positive; any area not covered by a tumor polygon is treated as background.
+The output mirrors the naming, multiscale hierarchy, and manifest schema used
+by ``sample_camelyon_multiscale_patches.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+from PIL import Image, ImageDraw
+
+# Disable PIL's decompression bomb check for very large whole-slide images.
+Image.MAX_IMAGE_PIXELS = None
+
+from sample_tcga_multiscale_patches import PatchTile, ValueLabelEncoder, compute_tissue_fraction
+
+
+@dataclass
+class BagResult:
+    """Stores the hierarchy node and associated tiles for a sampled bag."""
+
+    node: Dict[str, object]
+    tiles: List[PatchTile]
+
+
+SUPPORTED_IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".tif", ".tiff")
+SUPPORTED_JSON_EXTS = (".json",)
+
+CLASS_INFO = [
+    {"id": 0, "name": "Background", "abbr": "BKG"},
+    {"id": 1, "name": "Tumor", "abbr": "TUM"},
+]
+
+
+def _ensure_output_dir(out_root: Path, image_path: Path) -> Path:
+    out_dir = out_root / image_path.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _gather_images(image_root: Path, image_exts: Sequence[str]) -> List[Path]:
+    return [
+        path
+        for ext in image_exts
+        for path in sorted(image_root.glob(f"**/*{ext}"))
+        if path.is_file()
+    ]
+
+
+def _load_image(path: Path) -> Image.Image:
+    return Image.open(path).convert("RGB")
+
+
+def _parse_vertices(vertices) -> List[Tuple[int, int]]:
+    points: List[Tuple[int, int]] = []
+    if not isinstance(vertices, list):
+        return points
+
+    # Case: list of dicts with x/y keys
+    if vertices and isinstance(vertices[0], dict):
+        for pt in vertices:
+            if not isinstance(pt, dict):
+                continue
+            if "x" in pt and "y" in pt:
+                points.append((int(pt["x"]), int(pt["y"])))
+            elif "X" in pt and "Y" in pt:
+                points.append((int(pt["X"]), int(pt["Y"])))
+        return points
+
+    # Case: list of [x, y] pairs
+    if vertices and isinstance(vertices[0], (list, tuple)):
+        for pair in vertices:
+            if len(pair) >= 2:
+                points.append((int(pair[0]), int(pair[1])))
+        return points
+
+    # Case: flat list of numbers [x1, y1, x2, y2, ...]
+    if all(isinstance(v, (int, float)) for v in vertices) and len(vertices) % 2 == 0:
+        it = iter(vertices)
+        points = [(int(x), int(y)) for x, y in zip(it, it)]
+    return points
+
+
+def _extract_polygons(obj) -> List[List[Tuple[int, int]]]:
+    polygons: List[List[Tuple[int, int]]] = []
+
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            key_lower = str(key).lower()
+            if key_lower == "positive":
+                if isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, dict) and "vertices" in item:
+                            pts = _parse_vertices(item.get("vertices", []))
+                        else:
+                            pts = _parse_vertices(item)
+                        if len(pts) >= 3:
+                            polygons.append(pts)
+                else:
+                    pts = _parse_vertices(value)
+                    if len(pts) >= 3:
+                        polygons.append(pts)
+            else:
+                polygons.extend(_extract_polygons(value))
+    elif isinstance(obj, list):
+        for entry in obj:
+            polygons.extend(_extract_polygons(entry))
+
+    return polygons
+
+
+def _load_label_map(annotation_path: Path, size: Tuple[int, int]) -> np.ndarray:
+    width, height = size
+    with annotation_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    polygons = _extract_polygons(data)
+    label_map = np.zeros((height, width), dtype=np.int16)
+
+    if not polygons:
+        return label_map
+
+    mask_img = Image.new("L", (width, height), 0)
+    drawer = ImageDraw.Draw(mask_img)
+    for poly in polygons:
+        drawer.polygon(poly, outline=1, fill=1)
+
+    label_map[np.array(mask_img) > 0] = CLASS_INFO[1]["id"]
+    return label_map
+
+
+def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
+    if not scales:
+        return patch_size // 2
+    max_scale = max(scales) / scales[0]
+    margin = int(patch_size * max_scale / 2)
+    return max(1, margin)
+
+
+def _sample_centers(label_map: np.ndarray, count: int, margin: int, class_id: int) -> List[Tuple[int, int]]:
+    if count <= 0:
+        return []
+    coords = np.argwhere(label_map == class_id)
+    if len(coords) == 0:
+        return []
+    height, width = label_map.shape
+    valid = [
+        (int(x), int(y))
+        for y, x in coords
+        if margin <= x < width - margin and margin <= y < height - margin
+    ]
+    if not valid:
+        return []
+    random.shuffle(valid)
+    return valid[:count]
+
+
+def _extract_patch(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    patch_size: int,
+    scale_factor: float,
+    tissue_threshold: float,
+    background_threshold: int,
+    out_path: Path,
+) -> Optional[Path]:
+    window = max(1, int(round(patch_size * scale_factor)))
+    half = window // 2
+    left = center_x - half
+    top = center_y - half
+    right = left + window
+    bottom = top + window
+
+    if left < 0 or top < 0 or right > image.width or bottom > image.height:
+        return None
+
+    crop = image.crop((left, top, right, bottom))
+    if crop.size != (patch_size, patch_size):
+        crop = crop.resize((patch_size, patch_size), Image.BILINEAR)
+
+    tissue_fraction = compute_tissue_fraction(crop, background_threshold)
+    if tissue_fraction < tissue_threshold:
+        return None
+
+    crop.save(out_path)
+    return out_path
+
+
+def generate_hierarchy_from_image(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    scales: Sequence[float],
+    prefix: str,
+    out_dir: Path,
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+) -> Optional[BagResult]:
+    if not scales:
+        raise ValueError("At least one scale value must be provided")
+
+    root_tiles: List[PatchTile] = []
+    nodes: Dict[str, object] = {}
+
+    base_scale = float(scales[0])
+    parent: Optional[Dict[str, object]] = None
+
+    mag_map = {2.0: "5x", 1.0: "10x", 0.5: "20x", 0.25: "40x"}
+
+    for scale in scales:
+        if scale <= 0:
+            raise ValueError("Scale values must be positive")
+        window_factor = scale / base_scale
+        suffix = mag_map.get(scale, f"{scale:.2f}mpp")
+        patch_id = f"{prefix}_{suffix}"
+        out_path = out_dir / f"{patch_id}.png"
+
+        saved = _extract_patch(
+            image,
+            center_x,
+            center_y,
+            patch_size,
+            window_factor,
+            tissue_threshold,
+            background_threshold,
+            out_path,
+        )
+        if saved is None:
+            for tile in root_tiles:
+                try:
+                    tile.patch_path.unlink()
+                except FileNotFoundError:
+                    pass
+            return None
+
+        tile = PatchTile(
+            patch_id=patch_id,
+            patch_file=out_path.name,
+            patch_path=saved,
+            scale_suffix=suffix,
+        )
+        root_tiles.append(tile)
+
+        node: Dict[str, object] = {"id": patch_id, "file": out_path.name, "children": []}
+        if parent is not None:
+            parent.setdefault("children", []).append(node)
+        else:
+            nodes = node
+        parent = node
+
+    return BagResult(node=nodes, tiles=root_tiles)
+
+
+def _record_patch_rows(
+    rows: List[Dict[str, str]],
+    tiles: Iterable[PatchTile],
+    patient_id: str,
+    image_path: Path,
+    bag_index: int,
+    label_name: str,
+    label_id: int,
+) -> None:
+    for tile in tiles:
+        rows.append(
+            {
+                "patient_id": patient_id,
+                "pathology_id": image_path.name,
+                "subtype": label_name,
+                "labels": str(label_id),
+                "resolved_path": str(image_path),
+                "slide_stem": image_path.stem,
+                "bag_index": str(bag_index),
+                "bag_label": label_name,
+                "bag_label_id": str(label_id),
+                "patch_id": tile.patch_id,
+                "patch_file": tile.patch_file,
+                "patch_path": str(tile.patch_path),
+                "patch_scale": tile.scale_suffix,
+            }
+        )
+
+
+def _generate_patient_id(image_path: Path) -> str:
+    seed = abs(hash(image_path.stem.lower())) % 10**12
+    return f"{seed:012d}"
+
+
+def sample_image(
+    image_path: Path,
+    annotation_dir: Path,
+    out_root: Path,
+    positive_bags: int,
+    negative_bags: int,
+    seed: int,
+    scales: Sequence[float],
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+    label_encoder: ValueLabelEncoder,
+    json_exts: Sequence[str],
+) -> Tuple[List[Dict[str, object]], List[Dict[str, str]]]:
+    random.seed(seed)
+
+    annotation_path: Optional[Path] = None
+    for ext in json_exts:
+        candidate = annotation_dir / f"{image_path.stem}{ext}"
+        if candidate.exists():
+            annotation_path = candidate
+            break
+    if annotation_path is None:
+        raise ValueError(f"No annotation JSON found for {image_path.name} under {annotation_dir}")
+
+    image = _load_image(image_path)
+    label_map = _load_label_map(annotation_path, (image.width, image.height))
+
+    if label_map.shape[:2] != (image.height, image.width):
+        raise ValueError(
+            f"Annotation {annotation_path} does not match image dimensions for {image_path.name}: "
+            f"expected {(image.height, image.width)}, got {label_map.shape[:2]}"
+        )
+
+    out_dir = _ensure_output_dir(out_root, image_path)
+    margin = _compute_max_margin(patch_size, scales)
+
+    bags: List[Dict[str, object]] = []
+    patch_rows: List[Dict[str, str]] = []
+    patient_id = _generate_patient_id(image_path)
+
+    bag_index = 0
+    tumor_id = CLASS_INFO[1]["id"]
+    tumor_name = CLASS_INFO[1]["name"]
+    centers = _sample_centers(label_map, positive_bags, margin, tumor_id)
+    if centers:
+        label_id, label_name = label_encoder.encode(tumor_name)
+        for center_x, center_y in centers:
+            prefix = f"patch_{bag_index}"
+            bag = generate_hierarchy_from_image(
+                image,
+                center_x,
+                center_y,
+                list(scales),
+                prefix,
+                out_dir,
+                patch_size,
+                tissue_threshold,
+                background_threshold,
+            )
+            if not bag:
+                continue
+            bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+            bags.append(bag.node)
+            _record_patch_rows(
+                patch_rows,
+                bag.tiles,
+                patient_id,
+                image_path,
+                bag_index,
+                label_name,
+                label_id,
+            )
+            bag_index += 1
+
+    background_id, background_name = CLASS_INFO[0]["id"], CLASS_INFO[0]["name"]
+    centers_background = _sample_centers(label_map, negative_bags, margin, background_id)
+    if centers_background:
+        label_id, label_name = label_encoder.encode(background_name)
+        for center_x, center_y in centers_background:
+            prefix = f"patch_{bag_index}"
+            bag = generate_hierarchy_from_image(
+                image,
+                center_x,
+                center_y,
+                list(scales),
+                prefix,
+                out_dir,
+                patch_size,
+                tissue_threshold,
+                background_threshold,
+            )
+            if not bag:
+                continue
+            bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+            bags.append(bag.node)
+            _record_patch_rows(
+                patch_rows,
+                bag.tiles,
+                patient_id,
+                image_path,
+                bag_index,
+                label_name,
+                label_id,
+            )
+            bag_index += 1
+
+    bags_path = out_dir / "bags.json"
+    with bags_path.open("w", encoding="utf-8") as f:
+        json.dump(bags, f, indent=2)
+
+    return bags, patch_rows
+
+
+def _write_manifest(path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    rows = list(rows)
+    if not rows:
+        return
+    fieldnames = [
+        "patient_id",
+        "pathology_id",
+        "subtype",
+        "labels",
+        "resolved_path",
+        "slide_stem",
+        "bag_index",
+        "bag_label",
+        "bag_label_id",
+        "patch_id",
+        "patch_file",
+        "patch_path",
+        "patch_scale",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image_dir", type=Path, help="Directory containing BNCB images")
+    parser.add_argument(
+        "--annotation-dir",
+        type=Path,
+        default=None,
+        help="Directory containing JSON annotations (defaults to image_dir)",
+    )
+    parser.add_argument("output_dir", type=Path, help="Directory where patches and manifests are written")
+    parser.add_argument(
+        "--positive-bags", type=int, default=5, help="Number of tumor bags to sample per image"
+    )
+    parser.add_argument("--negative-bags", type=int, default=5, help="Number of background bags to sample per image")
+    parser.add_argument(
+        "--magnifications",
+        type=float,
+        nargs="+",
+        default=[2.0, 1.0, 0.5, 0.25],
+        help="Requested microns-per-pixel chain (coarse to fine)",
+    )
+    parser.add_argument("--patch-size", type=int, default=512, help="Output patch size in pixels")
+    parser.add_argument("--tissue-threshold", type=float, default=0.75, help="Minimum tissue fraction required to keep a patch")
+    parser.add_argument(
+        "--background-threshold",
+        type=int,
+        default=220,
+        help="Grayscale threshold that separates background from tissue",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used for reproducible sampling",
+    )
+    parser.add_argument(
+        "--image-exts",
+        nargs="+",
+        default=list(SUPPORTED_IMAGE_EXTS),
+        help="Image filename extensions to include",
+    )
+    parser.add_argument(
+        "--json-exts",
+        nargs="+",
+        default=list(SUPPORTED_JSON_EXTS),
+        help="Annotation filename extensions to search for",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    annotation_dir = args.annotation_dir or args.image_dir
+
+    images = _gather_images(args.image_dir, args.image_exts)
+    if not images:
+        raise SystemExit(f"No images found under {args.image_dir} with extensions {args.image_exts}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    label_encoder = ValueLabelEncoder({info["name"].lower(): (info["id"], info["name"]) for info in CLASS_INFO})
+
+    all_rows: List[Dict[str, str]] = []
+    for index, image_path in enumerate(images):
+        try:
+            _, patch_rows = sample_image(
+                image_path,
+                annotation_dir,
+                args.output_dir,
+                args.positive_bags,
+                args.negative_bags,
+                args.seed + index,
+                args.magnifications,
+                args.patch_size,
+                args.tissue_threshold,
+                args.background_threshold,
+                label_encoder,
+                args.json_exts,
+            )
+        except ValueError as e:
+            print(f"Warning: skipping {image_path} due to error: {e}")
+            continue
+        all_rows.extend(patch_rows)
+
+    manifest_path = args.output_dir / "patches.csv"
+    _write_manifest(manifest_path, all_rows)
+    print(f"Wrote patch manifest with {len(all_rows)} rows to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_dhmc_multiscale_patches.py
+++ b/scripts/sample_dhmc_multiscale_patches.py
@@ -420,6 +420,18 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _build_label_encoder(labels: Iterable[str]) -> ValueLabelEncoder:
+    """Create a label encoder that includes all diagnoses plus background."""
+
+    unique_labels = sorted({label.strip() for label in labels if label.strip()})
+    mapping: Dict[str, Tuple[int, str]] = {"background": (0, "Background")}
+
+    for idx, label in enumerate(unique_labels, start=1):
+        mapping[label] = (idx, label)
+
+    return ValueLabelEncoder(mapping)
+
+
 def main() -> None:
     args = parse_args()
 
@@ -429,7 +441,7 @@ def main() -> None:
         raise SystemExit(f"No images found under {args.image_dir} with extensions {args.image_exts}")
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    label_encoder = ValueLabelEncoder({"background": (0, "Background")})
+    label_encoder = _build_label_encoder(label_lookup.values())
 
     all_rows: List[Dict[str, str]] = []
     for index, image_path in enumerate(images):

--- a/scripts/sample_dhmc_multiscale_patches.py
+++ b/scripts/sample_dhmc_multiscale_patches.py
@@ -61,12 +61,36 @@ def _load_image(path: Path) -> Image.Image:
     return Image.open(path).convert("RGB")
 
 
-def _build_label_map(image: Image.Image, class_id: int, background_threshold: int) -> np.ndarray:
+def _build_label_map(
+    image: Image.Image, class_id: int, background_threshold: int, max_side: int = 4096
+) -> Tuple[np.ndarray, Tuple[float, float]]:
+    """Create a (possibly downscaled) label map and scale factors.
+
+    Whole-slide PNGs can be extremely large and exhaust memory when converted to
+    a full-resolution numpy array. To keep sampling lightweight, we optionally
+    downscale the label map to ``max_side`` on the longest dimension and return
+    per-axis scale factors for mapping centers back to the original resolution.
+    """
+
     gray = np.array(image.convert("L"))
     tissue_mask = gray < background_threshold
     label_map = np.zeros_like(gray, dtype=np.int16)
     label_map[tissue_mask] = class_id
-    return label_map
+
+    orig_h, orig_w = label_map.shape
+    longest = max(orig_h, orig_w)
+
+    if longest > max_side:
+        scale = longest / float(max_side)
+        new_w = max(1, int(round(orig_w / scale)))
+        new_h = max(1, int(round(orig_h / scale)))
+        label_map = np.array(Image.fromarray(label_map).resize((new_w, new_h), Image.NEAREST))
+    else:
+        scale = 1.0
+
+    scale_w = orig_w / float(label_map.shape[1])
+    scale_h = orig_h / float(label_map.shape[0])
+    return label_map, (scale_w, scale_h)
 
 
 def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
@@ -77,22 +101,42 @@ def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
     return max(1, margin)
 
 
-def _sample_centers(label_map: np.ndarray, count: int, margin: int, class_id: int) -> List[Tuple[int, int]]:
+def _sample_centers(
+    label_map: np.ndarray,
+    count: int,
+    margin: int,
+    class_id: int,
+    scale_factors: Tuple[float, float],
+    image_size: Tuple[int, int],
+) -> List[Tuple[int, int]]:
     if count <= 0:
         return []
     coords = np.argwhere(label_map == class_id)
     if len(coords) == 0:
         return []
     height, width = label_map.shape
+    scale_w, scale_h = scale_factors
+    margin_x = max(1, int(np.ceil(margin / scale_w)))
+    margin_y = max(1, int(np.ceil(margin / scale_h)))
+    img_w, img_h = image_size
     valid = [
-        (int(x), int(y))
+        (
+            int(round((x + 0.5) * scale_w)),
+            int(round((y + 0.5) * scale_h)),
+        )
         for y, x in coords
-        if margin <= x < width - margin and margin <= y < height - margin
+        if margin_x <= x < width - margin_x and margin_y <= y < height - margin_y
     ]
     if not valid:
         return []
     random.shuffle(valid)
-    return valid[:count]
+    trimmed: List[Tuple[int, int]] = []
+    for cx, cy in valid:
+        if margin <= cx < img_w - margin and margin <= cy < img_h - margin:
+            trimmed.append((cx, cy))
+        if len(trimmed) >= count:
+            break
+    return trimmed
 
 
 def _extract_patch(
@@ -265,7 +309,7 @@ def sample_image(
 
     image = _load_image(image_path)
     label_id, label_name = label_encoder.encode(diagnosis)
-    label_map = _build_label_map(image, label_id, background_threshold)
+    label_map, scale_factors = _build_label_map(image, label_id, background_threshold)
 
     out_dir = _ensure_output_dir(out_root, image_path)
     margin = _compute_max_margin(patch_size, scales)
@@ -275,7 +319,7 @@ def sample_image(
     patient_id = _generate_patient_id(image_path)
 
     bag_index = 0
-    centers = _sample_centers(label_map, positive_bags, margin, label_id)
+    centers = _sample_centers(label_map, positive_bags, margin, label_id, scale_factors, image.size)
     for center_x, center_y in centers:
         prefix = f"patch_{bag_index}"
         bag = generate_hierarchy_from_image(
@@ -307,7 +351,9 @@ def sample_image(
     background_id, background_name = label_encoder.encode("Background")
     if negative_bags > 0:
         bg_map = np.zeros_like(label_map)
-        centers_background = _sample_centers(bg_map, negative_bags, margin, background_id)
+        centers_background = _sample_centers(
+            bg_map, negative_bags, margin, background_id, scale_factors, image.size
+        )
         if centers_background:
             bg_label_id, bg_label_name = background_id, background_name
             for center_x, center_y in centers_background:

--- a/scripts/sample_dhmc_multiscale_patches.py
+++ b/scripts/sample_dhmc_multiscale_patches.py
@@ -64,29 +64,31 @@ def _load_image(path: Path) -> Image.Image:
 def _build_label_map(
     image: Image.Image, class_id: int, background_threshold: int, max_side: int = 4096
 ) -> Tuple[np.ndarray, Tuple[float, float]]:
-    """Create a (possibly downscaled) label map and scale factors.
+    """Create a memory-efficient label map and scale factors.
 
-    Whole-slide PNGs can be extremely large and exhaust memory when converted to
-    a full-resolution numpy array. To keep sampling lightweight, we optionally
-    downscale the label map to ``max_side`` on the longest dimension and return
-    per-axis scale factors for mapping centers back to the original resolution.
+    Instead of converting the full-resolution slide into a numpy array (which
+    can exhaust memory for very large PNGs), we optionally downscale the image
+    *before* converting to numpy. The resulting label map is small while the
+    returned scale factors preserve the mapping back to the original
+    resolution.
     """
 
-    gray = np.array(image.convert("L"))
-    tissue_mask = gray < background_threshold
-    label_map = np.zeros_like(gray, dtype=np.int16)
-    label_map[tissue_mask] = class_id
-
-    orig_h, orig_w = label_map.shape
-    longest = max(orig_h, orig_w)
+    orig_w, orig_h = image.size
+    longest = max(orig_w, orig_h)
 
     if longest > max_side:
         scale = longest / float(max_side)
         new_w = max(1, int(round(orig_w / scale)))
         new_h = max(1, int(round(orig_h / scale)))
-        label_map = np.array(Image.fromarray(label_map).resize((new_w, new_h), Image.NEAREST))
+        resized = image.convert("L").resize((new_w, new_h), Image.BILINEAR)
     else:
         scale = 1.0
+        resized = image.convert("L")
+
+    gray = np.array(resized)
+    tissue_mask = gray < background_threshold
+    label_map = np.zeros_like(gray, dtype=np.int16)
+    label_map[tissue_mask] = class_id
 
     scale_w = orig_w / float(label_map.shape[1])
     scale_h = orig_h / float(label_map.shape[0])

--- a/scripts/sample_dhmc_multiscale_patches.py
+++ b/scripts/sample_dhmc_multiscale_patches.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Sample multiscale patches for the DHMC dataset using slide-level diagnoses.
+
+Each PNG image has a corresponding row in a CSV file with two columns:
+"File name" and "Diagnosis". The diagnosis is treated as the slide-level
+label; patches are sampled from tissue regions only and inherit the slide's
+label. Output naming, multiscale hierarchy, and manifest schema mirror
+``sample_camelyon_multiscale_patches.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+from PIL import Image
+
+# Disable PIL's decompression bomb check for very large whole-slide images.
+Image.MAX_IMAGE_PIXELS = None
+
+from sample_tcga_multiscale_patches import (
+    PatchTile,
+    ValueLabelEncoder,
+    compute_tissue_fraction,
+)
+
+
+@dataclass
+class BagResult:
+    """Stores the hierarchy node and associated tiles for a sampled bag."""
+
+    node: Dict[str, object]
+    tiles: List[PatchTile]
+
+
+SUPPORTED_IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".tif", ".tiff")
+
+
+def _ensure_output_dir(out_root: Path, image_path: Path) -> Path:
+    out_dir = out_root / image_path.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _gather_images(image_root: Path, image_exts: Sequence[str]) -> List[Path]:
+    return [
+        path
+        for ext in image_exts
+        for path in sorted(image_root.glob(f"**/*{ext}"))
+        if path.is_file()
+    ]
+
+
+def _load_image(path: Path) -> Image.Image:
+    return Image.open(path).convert("RGB")
+
+
+def _build_label_map(image: Image.Image, class_id: int, background_threshold: int) -> np.ndarray:
+    gray = np.array(image.convert("L"))
+    tissue_mask = gray < background_threshold
+    label_map = np.zeros_like(gray, dtype=np.int16)
+    label_map[tissue_mask] = class_id
+    return label_map
+
+
+def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
+    if not scales:
+        return patch_size // 2
+    max_scale = max(scales) / scales[0]
+    margin = int(patch_size * max_scale / 2)
+    return max(1, margin)
+
+
+def _sample_centers(label_map: np.ndarray, count: int, margin: int, class_id: int) -> List[Tuple[int, int]]:
+    if count <= 0:
+        return []
+    coords = np.argwhere(label_map == class_id)
+    if len(coords) == 0:
+        return []
+    height, width = label_map.shape
+    valid = [
+        (int(x), int(y))
+        for y, x in coords
+        if margin <= x < width - margin and margin <= y < height - margin
+    ]
+    if not valid:
+        return []
+    random.shuffle(valid)
+    return valid[:count]
+
+
+def _extract_patch(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    patch_size: int,
+    scale_factor: float,
+    tissue_threshold: float,
+    background_threshold: int,
+    out_path: Path,
+) -> Optional[Path]:
+    window = max(1, int(round(patch_size * scale_factor)))
+    half = window // 2
+    left = center_x - half
+    top = center_y - half
+    right = left + window
+    bottom = top + window
+
+    if left < 0 or top < 0 or right > image.width or bottom > image.height:
+        return None
+
+    crop = image.crop((left, top, right, bottom))
+    if crop.size != (patch_size, patch_size):
+        crop = crop.resize((patch_size, patch_size), Image.BILINEAR)
+
+    tissue_fraction = compute_tissue_fraction(crop, background_threshold)
+    if tissue_fraction < tissue_threshold:
+        return None
+
+    crop.save(out_path)
+    return out_path
+
+
+def generate_hierarchy_from_image(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    scales: Sequence[float],
+    prefix: str,
+    out_dir: Path,
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+) -> Optional[BagResult]:
+    if not scales:
+        raise ValueError("At least one scale value must be provided")
+
+    root_tiles: List[PatchTile] = []
+    nodes: Dict[str, object] = {}
+
+    base_scale = float(scales[0])
+    parent: Optional[Dict[str, object]] = None
+
+    mag_map = {2.0: "5x", 1.0: "10x", 0.5: "20x", 0.25: "40x"}
+
+    for scale in scales:
+        if scale <= 0:
+            raise ValueError("Scale values must be positive")
+        window_factor = scale / base_scale
+        suffix = mag_map.get(scale, f"{scale:.2f}mpp")
+        patch_id = f"{prefix}_{suffix}"
+        out_path = out_dir / f"{patch_id}.png"
+
+        saved = _extract_patch(
+            image,
+            center_x,
+            center_y,
+            patch_size,
+            window_factor,
+            tissue_threshold,
+            background_threshold,
+            out_path,
+        )
+        if saved is None:
+            for tile in root_tiles:
+                try:
+                    tile.patch_path.unlink()
+                except FileNotFoundError:
+                    pass
+            return None
+
+        tile = PatchTile(
+            patch_id=patch_id,
+            patch_file=out_path.name,
+            patch_path=saved,
+            scale_suffix=suffix,
+        )
+        root_tiles.append(tile)
+
+        node: Dict[str, object] = {"id": patch_id, "file": out_path.name, "children": []}
+        if parent is not None:
+            parent.setdefault("children", []).append(node)
+        else:
+            nodes = node
+        parent = node
+
+    return BagResult(node=nodes, tiles=root_tiles)
+
+
+def _record_patch_rows(
+    rows: List[Dict[str, str]],
+    tiles: Iterable[PatchTile],
+    patient_id: str,
+    image_path: Path,
+    bag_index: int,
+    label_name: str,
+    label_id: int,
+) -> None:
+    for tile in tiles:
+        rows.append(
+            {
+                "patient_id": patient_id,
+                "pathology_id": image_path.name,
+                "subtype": label_name,
+                "labels": str(label_id),
+                "resolved_path": str(image_path),
+                "slide_stem": image_path.stem,
+                "bag_index": str(bag_index),
+                "bag_label": label_name,
+                "bag_label_id": str(label_id),
+                "patch_id": tile.patch_id,
+                "patch_file": tile.patch_file,
+                "patch_path": str(tile.patch_path),
+                "patch_scale": tile.scale_suffix,
+            }
+        )
+
+
+def _generate_patient_id(image_path: Path) -> str:
+    seed = abs(hash(image_path.stem.lower())) % 10**12
+    return f"{seed:012d}"
+
+
+def _read_labels(csv_path: Path, file_col: str, diagnosis_col: str) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    with csv_path.open("r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None or file_col not in reader.fieldnames or diagnosis_col not in reader.fieldnames:
+            raise ValueError(
+                f"CSV missing required columns '{file_col}' and '{diagnosis_col}': {reader.fieldnames}"
+            )
+        for row in reader:
+            filename = row[file_col].strip()
+            diagnosis = row[diagnosis_col].strip()
+            if not filename or not diagnosis:
+                continue
+            name = Path(filename).name.lower()
+            stem = Path(filename).stem.lower()
+            mapping[filename.lower()] = diagnosis
+            mapping[name] = diagnosis
+            mapping[stem] = diagnosis
+    return mapping
+
+
+def sample_image(
+    image_path: Path,
+    diagnosis: str,
+    out_root: Path,
+    positive_bags: int,
+    negative_bags: int,
+    seed: int,
+    scales: Sequence[float],
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+    label_encoder: ValueLabelEncoder,
+) -> Tuple[List[Dict[str, object]], List[Dict[str, str]]]:
+    random.seed(seed)
+
+    image = _load_image(image_path)
+    label_id, label_name = label_encoder.encode(diagnosis)
+    label_map = _build_label_map(image, label_id, background_threshold)
+
+    out_dir = _ensure_output_dir(out_root, image_path)
+    margin = _compute_max_margin(patch_size, scales)
+
+    bags: List[Dict[str, object]] = []
+    patch_rows: List[Dict[str, str]] = []
+    patient_id = _generate_patient_id(image_path)
+
+    bag_index = 0
+    centers = _sample_centers(label_map, positive_bags, margin, label_id)
+    for center_x, center_y in centers:
+        prefix = f"patch_{bag_index}"
+        bag = generate_hierarchy_from_image(
+            image,
+            center_x,
+            center_y,
+            list(scales),
+            prefix,
+            out_dir,
+            patch_size,
+            tissue_threshold,
+            background_threshold,
+        )
+        if not bag:
+            continue
+        bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+        bags.append(bag.node)
+        _record_patch_rows(
+            patch_rows,
+            bag.tiles,
+            patient_id,
+            image_path,
+            bag_index,
+            label_name,
+            label_id,
+        )
+        bag_index += 1
+
+    background_id, background_name = label_encoder.encode("Background")
+    if negative_bags > 0:
+        bg_map = np.zeros_like(label_map)
+        centers_background = _sample_centers(bg_map, negative_bags, margin, background_id)
+        if centers_background:
+            bg_label_id, bg_label_name = background_id, background_name
+            for center_x, center_y in centers_background:
+                prefix = f"patch_{bag_index}"
+                bag = generate_hierarchy_from_image(
+                    image,
+                    center_x,
+                    center_y,
+                    list(scales),
+                    prefix,
+                    out_dir,
+                    patch_size,
+                    tissue_threshold,
+                    background_threshold,
+                )
+                if not bag:
+                    continue
+                bag.node.update({"label": bg_label_name, "label_id": bg_label_id, "center": [center_x, center_y]})
+                bags.append(bag.node)
+                _record_patch_rows(
+                    patch_rows,
+                    bag.tiles,
+                    patient_id,
+                    image_path,
+                    bag_index,
+                    bg_label_name,
+                    bg_label_id,
+                )
+                bag_index += 1
+
+    bags_path = out_dir / "bags.json"
+    with bags_path.open("w", encoding="utf-8") as f:
+        json.dump(bags, f, indent=2)
+
+    return bags, patch_rows
+
+
+def _write_manifest(path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    rows = list(rows)
+    if not rows:
+        return
+    fieldnames = [
+        "patient_id",
+        "pathology_id",
+        "subtype",
+        "labels",
+        "resolved_path",
+        "slide_stem",
+        "bag_index",
+        "bag_label",
+        "bag_label_id",
+        "patch_id",
+        "patch_file",
+        "patch_path",
+        "patch_scale",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image_dir", type=Path, help="Directory containing DHMC PNG images")
+    parser.add_argument("metadata_csv", type=Path, help="CSV with 'File name' and 'Diagnosis' columns")
+    parser.add_argument("output_dir", type=Path, help="Directory where patches and manifests are written")
+    parser.add_argument(
+        "--file-column",
+        type=str,
+        default="File name",
+        help="CSV column that stores the image file name",
+    )
+    parser.add_argument(
+        "--diagnosis-column",
+        type=str,
+        default="Diagnosis",
+        help="CSV column that stores the diagnosis/subtype label",
+    )
+    parser.add_argument("--positive-bags", type=int, default=5, help="Number of labeled bags to sample per image")
+    parser.add_argument("--negative-bags", type=int, default=0, help="Number of background bags to sample per image")
+    parser.add_argument(
+        "--magnifications",
+        type=float,
+        nargs="+",
+        default=[2.0, 1.0, 0.5, 0.25],
+        help="Requested microns-per-pixel chain (coarse to fine)",
+    )
+    parser.add_argument("--patch-size", type=int, default=512, help="Output patch size in pixels")
+    parser.add_argument("--tissue-threshold", type=float, default=0.75, help="Minimum tissue fraction required to keep a patch")
+    parser.add_argument(
+        "--background-threshold",
+        type=int,
+        default=220,
+        help="Grayscale threshold that separates background from tissue",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used for reproducible sampling",
+    )
+    parser.add_argument(
+        "--image-exts",
+        nargs="+",
+        default=list(SUPPORTED_IMAGE_EXTS),
+        help="Image filename extensions to include",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    label_lookup = _read_labels(args.metadata_csv, args.file_column, args.diagnosis_column)
+    images = _gather_images(args.image_dir, args.image_exts)
+    if not images:
+        raise SystemExit(f"No images found under {args.image_dir} with extensions {args.image_exts}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    label_encoder = ValueLabelEncoder({"background": (0, "Background")})
+
+    all_rows: List[Dict[str, str]] = []
+    for index, image_path in enumerate(images):
+        key = image_path.name.lower()
+        if key not in label_lookup:
+            print(f"Warning: skipping {image_path.name} because no diagnosis was found in metadata")
+            continue
+        diagnosis = label_lookup[key]
+        try:
+            _, patch_rows = sample_image(
+                image_path,
+                diagnosis,
+                args.output_dir,
+                args.positive_bags,
+                args.negative_bags,
+                args.seed + index,
+                args.magnifications,
+                args.patch_size,
+                args.tissue_threshold,
+                args.background_threshold,
+                label_encoder,
+            )
+        except ValueError as e:
+            print(f"Warning: skipping {image_path} due to error: {e}")
+            continue
+        all_rows.extend(patch_rows)
+
+    manifest_path = args.output_dir / "patches.csv"
+    _write_manifest(manifest_path, all_rows)
+    print(f"Wrote patch manifest with {len(all_rows)} rows to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_imp_multiscale_patches.py
+++ b/scripts/sample_imp_multiscale_patches.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Sample multiscale patches for the IMP dataset using folder names as labels.
+
+Dataset layout::
+
+    imp_root/
+      0/               # label "0"
+        slide_a.svs
+        slide_b.svs
+      1/               # label "1"
+        slide_c.svs
+      2/               # label "2"
+        slide_d.svs
+
+Each subfolder name is treated as the slide-level label for all contained
+slides. The script samples tissue-centered patch hierarchies at multiple
+magnifications, names patches with the reference 5×/10×/20×/40× suffixes, and
+writes a ``patches.csv`` manifest matching ``sample_camelyon_multiscale_patches.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+import openslide
+from PIL import Image
+
+from sample_tcga_multiscale_patches import PatchTile, ValueLabelEncoder, compute_tissue_fraction
+
+# Disable PIL decompression checks for very large WSIs.
+Image.MAX_IMAGE_PIXELS = None
+
+SUPPORTED_IMAGE_EXTS = (".svs", ".tif", ".tiff")
+
+
+@dataclass
+class BagResult:
+    node: Dict[str, object]
+    tiles: List[PatchTile]
+
+
+def _ensure_output_dir(out_root: Path, slide_path: Path) -> Path:
+    out_dir = out_root / slide_path.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _gather_labeled_slides(root: Path, exts: Sequence[str]) -> List[Tuple[Path, str]]:
+    slides: List[Tuple[Path, str]] = []
+    if not root.exists():
+        return slides
+    for label_dir in sorted(p for p in root.iterdir() if p.is_dir()):
+        label_name = label_dir.name
+        for ext in exts:
+            for slide_path in sorted(label_dir.glob(f"**/*{ext}")):
+                if slide_path.is_file():
+                    slides.append((slide_path, label_name))
+    return slides
+
+
+def _build_label_map(
+    slide: openslide.OpenSlide,
+    class_id: int,
+    background_threshold: int,
+    max_side: int = 2048,
+) -> Tuple[np.ndarray, Tuple[float, float]]:
+    width, height = slide.dimensions
+    longest = max(width, height)
+    if longest > max_side:
+        scale = longest / float(max_side)
+        thumb_size = (max(1, int(round(width / scale))), max(1, int(round(height / scale))))
+    else:
+        thumb_size = (width, height)
+
+    thumb = slide.get_thumbnail(thumb_size).convert("L")
+    gray = np.array(thumb)
+    tissue_mask = gray < background_threshold
+
+    label_map = np.zeros_like(gray, dtype=np.int16)
+    label_map[tissue_mask] = class_id
+
+    scale_w = width / float(label_map.shape[1])
+    scale_h = height / float(label_map.shape[0])
+    return label_map, (scale_w, scale_h)
+
+
+def _select_level(slide: openslide.OpenSlide, requested_ds: float) -> int:
+    downsamples = slide.level_downsamples
+    closest = min(range(len(downsamples)), key=lambda idx: abs(downsamples[idx] - requested_ds))
+    return int(closest)
+
+
+def _compute_max_margin(patch_size: int, scales: Sequence[float], base_mpp: float) -> int:
+    if not scales:
+        return patch_size // 2
+    largest = max(scales)
+    requested_window = patch_size * (largest / base_mpp)
+    return max(1, int(round(requested_window / 2)))
+
+
+def _sample_centers(
+    label_map: np.ndarray,
+    count: int,
+    margin: int,
+    class_id: int,
+    scale_factors: Tuple[float, float],
+    image_size: Tuple[int, int],
+) -> List[Tuple[int, int]]:
+    if count <= 0:
+        return []
+    coords = np.argwhere(label_map == class_id)
+    if len(coords) == 0:
+        return []
+    height, width = label_map.shape
+    scale_w, scale_h = scale_factors
+    margin_x = max(1, int(np.ceil(margin / scale_w)))
+    margin_y = max(1, int(np.ceil(margin / scale_h)))
+    img_w, img_h = image_size
+    valid: List[Tuple[int, int]] = []
+    for y, x in coords:
+        if margin_x <= x < width - margin_x and margin_y <= y < height - margin_y:
+            cx = int(round((x + 0.5) * scale_w))
+            cy = int(round((y + 0.5) * scale_h))
+            if margin <= cx < img_w - margin and margin <= cy < img_h - margin:
+                valid.append((cx, cy))
+    if not valid:
+        return []
+    random.shuffle(valid)
+    return valid[:count]
+
+
+def _extract_patch(
+    slide: openslide.OpenSlide,
+    center_x: int,
+    center_y: int,
+    requested_mpp: float,
+    base_mpp: float,
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+    out_path: Path,
+) -> Optional[Path]:
+    requested_ds = requested_mpp / base_mpp
+    level = _select_level(slide, requested_ds)
+    actual_ds = slide.level_downsamples[level]
+
+    half = patch_size * requested_ds / 2
+    x0 = int(round(center_x - half))
+    y0 = int(round(center_y - half))
+    region_size = int(round(patch_size * requested_ds / actual_ds))
+
+    img = slide.read_region((x0, y0), level, (region_size, region_size)).convert("RGB")
+    if img.size != (patch_size, patch_size):
+        img = img.resize((patch_size, patch_size), Image.BILINEAR)
+
+    tissue_fraction = compute_tissue_fraction(img, background_threshold)
+    if tissue_fraction < tissue_threshold:
+        return None
+
+    img.save(out_path)
+    return out_path
+
+
+def generate_hierarchy_from_slide(
+    slide: openslide.OpenSlide,
+    center_x: int,
+    center_y: int,
+    mpps: Sequence[float],
+    prefix: str,
+    out_dir: Path,
+    base_mpp: float,
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+) -> Optional[BagResult]:
+    if not mpps:
+        raise ValueError("At least one magnification value must be provided")
+
+    base_scale = float(mpps[0])
+    mag_map = {2.0: "5x", 1.0: "10x", 0.5: "20x", 0.25: "40x"}
+
+    tiles: List[PatchTile] = []
+    nodes: Dict[str, object] = {}
+    parent: Optional[Dict[str, object]] = None
+
+    for mpp in mpps:
+        if mpp <= 0:
+            raise ValueError("Magnification values must be positive")
+        window_factor = mpp / base_scale
+        suffix = mag_map.get(mpp, f"{mpp:.2f}mpp")
+        patch_id = f"{prefix}_{suffix}"
+        out_path = out_dir / f"{patch_id}.png"
+
+        saved = _extract_patch(
+            slide,
+            center_x,
+            center_y,
+            mpp,
+            base_mpp,
+            patch_size,
+            tissue_threshold,
+            background_threshold,
+            out_path,
+        )
+        if saved is None:
+            for tile in tiles:
+                try:
+                    tile.patch_path.unlink()
+                except FileNotFoundError:
+                    pass
+            return None
+
+        tile = PatchTile(patch_id=patch_id, patch_file=out_path.name, patch_path=saved, scale_suffix=suffix)
+        tiles.append(tile)
+
+        node: Dict[str, object] = {"id": patch_id, "file": out_path.name, "children": []}
+        if parent is not None:
+            parent.setdefault("children", []).append(node)
+        else:
+            nodes = node
+        parent = node
+
+    return BagResult(node=nodes, tiles=tiles)
+
+
+def _record_patch_rows(
+    rows: List[Dict[str, str]],
+    tiles: Iterable[PatchTile],
+    patient_id: str,
+    slide_path: Path,
+    bag_index: int,
+    label_name: str,
+    label_id: int,
+) -> None:
+    for tile in tiles:
+        rows.append(
+            {
+                "patient_id": patient_id,
+                "pathology_id": slide_path.name,
+                "subtype": label_name,
+                "labels": str(label_id),
+                "resolved_path": str(slide_path),
+                "slide_stem": slide_path.stem,
+                "bag_index": str(bag_index),
+                "bag_label": label_name,
+                "bag_label_id": str(label_id),
+                "patch_id": tile.patch_id,
+                "patch_file": tile.patch_file,
+                "patch_path": str(tile.patch_path),
+                "patch_scale": tile.scale_suffix,
+            }
+        )
+
+
+def _generate_patient_id(slide_path: Path) -> str:
+    seed = abs(hash(slide_path.stem.lower())) % 10**12
+    return f"{seed:012d}"
+
+
+def _write_manifest(path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    rows = list(rows)
+    if not rows:
+        return
+    fieldnames = [
+        "patient_id",
+        "pathology_id",
+        "subtype",
+        "labels",
+        "resolved_path",
+        "slide_stem",
+        "bag_index",
+        "bag_label",
+        "bag_label_id",
+        "patch_id",
+        "patch_file",
+        "patch_path",
+        "patch_scale",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def sample_slide(
+    slide_path: Path,
+    slide_label: str,
+    out_root: Path,
+    positive_bags: int,
+    negative_bags: int,
+    seed: int,
+    mpps: Sequence[float],
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+    label_encoder: ValueLabelEncoder,
+) -> Tuple[List[Dict[str, object]], List[Dict[str, str]]]:
+    random.seed(seed)
+
+    slide = openslide.OpenSlide(str(slide_path))
+    base_mpp = float(slide.properties.get("openslide.mpp-x", 0.25))
+
+    label_id, label_name = label_encoder.encode(slide_label)
+    label_map, scale_factors = _build_label_map(slide, label_id, background_threshold)
+
+    out_dir = _ensure_output_dir(out_root, slide_path)
+    margin = _compute_max_margin(patch_size, mpps, base_mpp)
+
+    bags: List[Dict[str, object]] = []
+    patch_rows: List[Dict[str, str]] = []
+    patient_id = _generate_patient_id(slide_path)
+
+    bag_index = 0
+    centers = _sample_centers(label_map, positive_bags, margin, label_id, scale_factors, slide.dimensions)
+    for center_x, center_y in centers:
+        prefix = f"patch_{bag_index}"
+        bag = generate_hierarchy_from_slide(
+            slide,
+            center_x,
+            center_y,
+            list(mpps),
+            prefix,
+            out_dir,
+            base_mpp,
+            patch_size,
+            tissue_threshold,
+            background_threshold,
+        )
+        if not bag:
+            continue
+        bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+        bags.append(bag.node)
+        _record_patch_rows(
+            patch_rows,
+            bag.tiles,
+            patient_id,
+            slide_path,
+            bag_index,
+            label_name,
+            label_id,
+        )
+        bag_index += 1
+
+    background_id, background_name = label_encoder.encode("Background")
+    if negative_bags > 0:
+        bg_map = np.zeros_like(label_map)
+        centers_background = _sample_centers(bg_map, negative_bags, margin, background_id, scale_factors, slide.dimensions)
+        for center_x, center_y in centers_background:
+            prefix = f"patch_{bag_index}"
+            bag = generate_hierarchy_from_slide(
+                slide,
+                center_x,
+                center_y,
+                list(mpps),
+                prefix,
+                out_dir,
+                base_mpp,
+                patch_size,
+                tissue_threshold,
+                background_threshold,
+            )
+            if not bag:
+                continue
+            bag.node.update({"label": background_name, "label_id": background_id, "center": [center_x, center_y]})
+            bags.append(bag.node)
+            _record_patch_rows(
+                patch_rows,
+                bag.tiles,
+                patient_id,
+                slide_path,
+                bag_index,
+                background_name,
+                background_id,
+            )
+            bag_index += 1
+
+    bags_path = out_dir / "bags.json"
+    with bags_path.open("w", encoding="utf-8") as f:
+        json.dump(bags, f, indent=2)
+
+    return bags, patch_rows
+
+
+def _build_label_encoder(labels: Iterable[str]) -> ValueLabelEncoder:
+    unique_labels = sorted({label.strip() for label in labels if label.strip()})
+    mapping: Dict[str, Tuple[int, str]] = {"background": (0, "Background")}
+    for idx, label in enumerate(unique_labels, start=1):
+        mapping[label] = (idx, label)
+    return ValueLabelEncoder(mapping)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("imp_root", type=Path, help="Root directory containing label-named folders (e.g., 0/1/2)")
+    parser.add_argument("output_dir", type=Path, help="Directory where patches and manifests are written")
+    parser.add_argument("--positive-bags", type=int, default=5, help="Number of labeled bags to sample per slide")
+    parser.add_argument("--negative-bags", type=int, default=0, help="Number of background bags to sample per slide")
+    parser.add_argument("--magnifications", type=float, nargs="+", default=[2.0, 1.0, 0.5, 0.25], help="Microns-per-pixel chain (coarse to fine)")
+    parser.add_argument("--patch-size", type=int, default=512, help="Output patch size in pixels")
+    parser.add_argument("--tissue-threshold", type=float, default=0.75, help="Minimum tissue fraction required to keep a patch")
+    parser.add_argument("--background-threshold", type=int, default=220, help="Grayscale threshold separating tissue from background")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for reproducible sampling")
+    parser.add_argument("--image-exts", nargs="+", default=list(SUPPORTED_IMAGE_EXTS), help="Slide filename extensions to include")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    slides = _gather_labeled_slides(args.imp_root, args.image_exts)
+    if not slides:
+        raise SystemExit(f"No slides found under {args.imp_root} with extensions {args.image_exts}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    label_encoder = _build_label_encoder(label for _, label in slides)
+
+    all_rows: List[Dict[str, str]] = []
+    for idx, (slide_path, label_name) in enumerate(slides):
+        try:
+            _, patch_rows = sample_slide(
+                slide_path,
+                label_name,
+                args.output_dir,
+                args.positive_bags,
+                args.negative_bags,
+                args.seed + idx,
+                args.magnifications,
+                args.patch_size,
+                args.tissue_threshold,
+                args.background_threshold,
+                label_encoder,
+            )
+        except Exception as exc:
+            print(f"Warning: skipping {slide_path} due to error: {exc}")
+            continue
+        all_rows.extend(patch_rows)
+
+    manifest_path = args.output_dir / "patches.csv"
+    _write_manifest(manifest_path, all_rows)
+    print(f"Wrote patch manifest with {len(all_rows)} rows to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_mask_multiscale_patches.py
+++ b/scripts/sample_mask_multiscale_patches.py
@@ -26,6 +26,9 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 import numpy as np
 from PIL import Image
 
+# Disable PIL's decompression bomb check for very large whole-slide images.
+Image.MAX_IMAGE_PIXELS = None
+
 from sample_tcga_multiscale_patches import PatchTile, ValueLabelEncoder, compute_tissue_fraction
 
 
@@ -75,7 +78,10 @@ def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
 def _sample_centers(mask: np.ndarray, count: int, margin: int, positive: bool) -> List[Tuple[int, int]]:
     if count <= 0:
         return []
-    coords = np.argwhere(mask > 0) if positive else np.argwhere(mask == 0)
+    mask_binary = mask
+    if mask.ndim == 3:
+        mask_binary = mask.any(axis=-1)
+    coords = np.argwhere(mask_binary > 0) if positive else np.argwhere(mask_binary == 0)
     if len(coords) == 0:
         return []
     height, width = mask.shape[:2]

--- a/scripts/sample_mask_multiscale_patches.py
+++ b/scripts/sample_mask_multiscale_patches.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+"""Sample multi-scale patches from paired image/mask datasets.
+
+This script mirrors the multi-scale patch generation pipeline used for
+whole-slide images but operates on conventional paired images and masks. It
+supports datasets where images and masks share a filename stem (for example,
+``foo.jpg`` alongside ``foo.png``) and works with multiple file formats,
+including TIFF. Positive patch centers are sampled from non-zero mask pixels,
+while negative centers come from background regions.
+
+The resulting hierarchy for each sampled bag is saved beneath an image-specific
+output directory alongside a ``bags.json`` description and an aggregated
+``patches.csv`` manifest that lists every generated patch tile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
+from PIL import Image
+
+from sample_tcga_multiscale_patches import PatchTile, ValueLabelEncoder, compute_tissue_fraction
+
+
+@dataclass
+class BagResult:
+    """Stores the hierarchy node and associated tiles for a sampled bag."""
+
+    node: Dict[str, object]
+    tiles: List[PatchTile]
+
+
+SUPPORTED_IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".tif", ".tiff")
+SUPPORTED_MASK_EXTS = (".png", ".tif", ".tiff")
+
+
+def _ensure_output_dir(out_root: Path, image_path: Path) -> Path:
+    out_dir = out_root / image_path.stem
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir
+
+
+def _find_mask(mask_dir: Path, image_path: Path, mask_exts: Sequence[str]) -> Optional[Path]:
+    for ext in mask_exts:
+        candidate = mask_dir / f"{image_path.stem}{ext}"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _load_image(path: Path) -> Image.Image:
+    return Image.open(path).convert("RGB")
+
+
+def _load_mask(path: Path) -> np.ndarray:
+    mask = Image.open(path)
+    return np.array(mask)
+
+
+def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
+    if not scales:
+        return patch_size // 2
+    max_scale = max(scales) / scales[0]
+    margin = int(patch_size * max_scale / 2)
+    return max(1, margin)
+
+
+def _sample_centers(mask: np.ndarray, count: int, margin: int, positive: bool) -> List[Tuple[int, int]]:
+    if count <= 0:
+        return []
+    coords = np.argwhere(mask > 0) if positive else np.argwhere(mask == 0)
+    if len(coords) == 0:
+        return []
+    height, width = mask.shape[:2]
+    valid = [
+        (int(x), int(y))
+        for y, x in coords
+        if margin <= x < width - margin and margin <= y < height - margin
+    ]
+    if not valid:
+        return []
+    random.shuffle(valid)
+    return valid[:count]
+
+
+def _extract_patch(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    patch_size: int,
+    scale_factor: float,
+    tissue_threshold: float,
+    background_threshold: int,
+    out_path: Path,
+) -> Optional[Path]:
+    window = max(1, int(round(patch_size * scale_factor)))
+    half = window // 2
+    left = center_x - half
+    top = center_y - half
+    right = left + window
+    bottom = top + window
+
+    if left < 0 or top < 0 or right > image.width or bottom > image.height:
+        return None
+
+    crop = image.crop((left, top, right, bottom))
+    if crop.size != (patch_size, patch_size):
+        crop = crop.resize((patch_size, patch_size), Image.BILINEAR)
+
+    tissue_fraction = compute_tissue_fraction(crop, background_threshold)
+    if tissue_fraction < tissue_threshold:
+        return None
+
+    crop.save(out_path)
+    return out_path
+
+
+def generate_hierarchy_from_image(
+    image: Image.Image,
+    center_x: int,
+    center_y: int,
+    scales: Sequence[float],
+    prefix: str,
+    out_dir: Path,
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+) -> Optional[BagResult]:
+    if not scales:
+        raise ValueError("At least one scale value must be provided")
+
+    root_tiles: List[PatchTile] = []
+    nodes: Dict[str, object] = {}
+
+    base_scale = float(scales[0])
+    parent: Optional[Dict[str, object]] = None
+
+    for scale in scales:
+        if scale <= 0:
+            raise ValueError("Scale values must be positive")
+        window_factor = scale / base_scale
+        suffix = f"{scale:.2f}mpp"
+        patch_id = f"{prefix}_{suffix}"
+        out_path = out_dir / f"{patch_id}.png"
+
+        saved = _extract_patch(
+            image,
+            center_x,
+            center_y,
+            patch_size,
+            window_factor,
+            tissue_threshold,
+            background_threshold,
+            out_path,
+        )
+        if saved is None:
+            for tile in root_tiles:
+                try:
+                    tile.patch_path.unlink()
+                except FileNotFoundError:
+                    pass
+            return None
+
+        tile = PatchTile(
+            patch_id=patch_id,
+            patch_file=out_path.name,
+            patch_path=saved,
+            scale_suffix=suffix,
+        )
+        root_tiles.append(tile)
+
+        node: Dict[str, object] = {"id": patch_id, "file": out_path.name, "children": []}
+        if parent is not None:
+            parent.setdefault("children", []).append(node)
+        else:
+            nodes = node
+        parent = node
+
+    return BagResult(node=nodes, tiles=root_tiles)
+
+
+def _record_patch_rows(
+    rows: List[Dict[str, str]],
+    tiles: Iterable[PatchTile],
+    image_path: Path,
+    bag_index: int,
+    label_name: str,
+    label_id: int,
+) -> None:
+    for tile in tiles:
+        rows.append(
+            {
+                "image_file": image_path.name,
+                "image_stem": image_path.stem,
+                "bag_index": str(bag_index),
+                "bag_label": label_name,
+                "bag_label_id": str(label_id),
+                "patch_id": tile.patch_id,
+                "patch_file": tile.patch_file,
+                "patch_path": str(tile.patch_path),
+                "patch_scale": tile.scale_suffix,
+            }
+        )
+
+
+def sample_image(
+    image_path: Path,
+    mask_path: Path,
+    out_root: Path,
+    positive_bags: int,
+    negative_bags: int,
+    seed: int,
+    scales: Sequence[float],
+    patch_size: int,
+    tissue_threshold: float,
+    background_threshold: int,
+    label_encoder: ValueLabelEncoder,
+) -> Tuple[List[Dict[str, object]], List[Dict[str, str]]]:
+    random.seed(seed)
+
+    image = _load_image(image_path)
+    mask = _load_mask(mask_path)
+    if mask.shape[:2] != (image.height, image.width):
+        raise ValueError(
+            f"Mask {mask_path} does not match image dimensions for {image_path.name}: "
+            f"expected {(image.height, image.width)}, got {mask.shape[:2]}"
+        )
+
+    out_dir = _ensure_output_dir(out_root, image_path)
+    margin = _compute_max_margin(patch_size, scales)
+    positive_centers = _sample_centers(mask, positive_bags, margin, positive=True)
+    negative_centers = _sample_centers(mask, negative_bags, margin, positive=False)
+
+    bags: List[Dict[str, object]] = []
+    patch_rows: List[Dict[str, str]] = []
+    label_pos_id, label_pos_name = label_encoder.encode("Positive")
+    label_neg_id, label_neg_name = label_encoder.encode("Negative")
+
+    bag_index = 0
+    for center_x, center_y in positive_centers:
+        prefix = f"patch_{bag_index}"
+        bag = generate_hierarchy_from_image(
+            image,
+            center_x,
+            center_y,
+            list(scales),
+            prefix,
+            out_dir,
+            patch_size,
+            tissue_threshold,
+            background_threshold,
+        )
+        if not bag:
+            continue
+        bag.node.update({"label": label_pos_name, "label_id": label_pos_id, "center": [center_x, center_y]})
+        bags.append(bag.node)
+        _record_patch_rows(patch_rows, bag.tiles, image_path, bag_index, label_pos_name, label_pos_id)
+        bag_index += 1
+
+    for center_x, center_y in negative_centers:
+        prefix = f"patch_{bag_index}"
+        bag = generate_hierarchy_from_image(
+            image,
+            center_x,
+            center_y,
+            list(scales),
+            prefix,
+            out_dir,
+            patch_size,
+            tissue_threshold,
+            background_threshold,
+        )
+        if not bag:
+            continue
+        bag.node.update({"label": label_neg_name, "label_id": label_neg_id, "center": [center_x, center_y]})
+        bags.append(bag.node)
+        _record_patch_rows(patch_rows, bag.tiles, image_path, bag_index, label_neg_name, label_neg_id)
+        bag_index += 1
+
+    bags_path = out_dir / "bags.json"
+    with bags_path.open("w", encoding="utf-8") as f:
+        json.dump(bags, f, indent=2)
+
+    return bags, patch_rows
+
+
+def _gather_images(image_root: Path, image_exts: Sequence[str]) -> List[Path]:
+    candidates = [
+        path
+        for ext in image_exts
+        for path in sorted(image_root.glob(f"**/*{ext}"))
+        if path.is_file()
+    ]
+    return candidates
+
+
+def _write_manifest(path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    fieldnames = [
+        "image_file",
+        "image_stem",
+        "bag_index",
+        "bag_label",
+        "bag_label_id",
+        "patch_id",
+        "patch_file",
+        "patch_path",
+        "patch_scale",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image_dir", type=Path, help="Root directory containing input images")
+    parser.add_argument(
+        "mask_dir",
+        type=Path,
+        help="Root directory containing masks that share the same filename stem as images",
+    )
+    parser.add_argument("output_dir", type=Path, help="Directory where patches and manifests are written")
+    parser.add_argument("--positive-bags", type=int, default=5, help="Number of positive bags to sample per image")
+    parser.add_argument("--negative-bags", type=int, default=5, help="Number of negative bags to sample per image")
+    parser.add_argument(
+        "--magnifications",
+        type=float,
+        nargs="+",
+        default=[2.0, 1.0, 0.5, 0.25],
+        help="Requested microns-per-pixel chain (coarse to fine)",
+    )
+    parser.add_argument("--patch-size", type=int, default=512, help="Output patch size in pixels")
+    parser.add_argument("--tissue-threshold", type=float, default=0.75, help="Minimum tissue fraction required to keep a patch")
+    parser.add_argument(
+        "--background-threshold",
+        type=int,
+        default=220,
+        help="Grayscale threshold that separates background from tissue",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed used for reproducible sampling",
+    )
+    parser.add_argument(
+        "--image-exts",
+        nargs="+",
+        default=list(SUPPORTED_IMAGE_EXTS),
+        help="Image filename extensions to include (default: common JPEG/PNG/TIFF)",
+    )
+    parser.add_argument(
+        "--mask-exts",
+        nargs="+",
+        default=list(SUPPORTED_MASK_EXTS),
+        help="Mask filename extensions to search for (checked in order)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    images = _gather_images(args.image_dir, args.image_exts)
+    if not images:
+        raise SystemExit(f"No images found under {args.image_dir} with extensions {args.image_exts}")
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    label_encoder = ValueLabelEncoder({"positive": (1, "Positive"), "negative": (0, "Negative")})
+
+    all_rows: List[Dict[str, str]] = []
+    for index, image_path in enumerate(images):
+        mask_path = _find_mask(args.mask_dir, image_path, args.mask_exts)
+        if mask_path is None:
+            print(f"Warning: skipping {image_path} because no matching mask was found")
+            continue
+        print(f"Processing {image_path}")
+        _, patch_rows = sample_image(
+            image_path,
+            mask_path,
+            args.output_dir,
+            args.positive_bags,
+            args.negative_bags,
+            args.seed + index,
+            args.magnifications,
+            args.patch_size,
+            args.tissue_threshold,
+            args.background_threshold,
+            label_encoder,
+        )
+        all_rows.extend(patch_rows)
+
+    manifest_path = args.output_dir / "patches.csv"
+    _write_manifest(manifest_path, all_rows)
+    print(f"Wrote patch manifest with {len(all_rows)} rows to {manifest_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sample_mask_multiscale_patches.py
+++ b/scripts/sample_mask_multiscale_patches.py
@@ -5,8 +5,9 @@ This script mirrors the multi-scale patch generation pipeline used for
 whole-slide images but operates on conventional paired images and masks. It
 supports datasets where images and masks share a filename stem (for example,
 ``foo.jpg`` alongside ``foo.png``) and works with multiple file formats,
-including TIFF. Positive patch centers are sampled from non-zero mask pixels,
-while negative centers come from background regions.
+including TIFF. Positive patch centers are sampled from colored mask pixels
+(per-class if a color map is available), while negative centers come from
+background regions.
 
 The resulting hierarchy for each sampled bag is saved beneath an image-specific
 output directory alongside a ``bags.json`` description and an aggregated
@@ -44,6 +45,27 @@ SUPPORTED_IMAGE_EXTS = (".jpg", ".jpeg", ".png", ".tif", ".tiff")
 SUPPORTED_MASK_EXTS = (".png", ".tif", ".tiff")
 
 
+CLASS_INFO = [
+    {"id": 0, "name": "Background", "abbr": "BKG", "color": (0, 0, 0)},
+    {"id": 1, "name": "Keratin", "abbr": "KER", "color": (224, 224, 224)},
+    {"id": 2, "name": "Epidermis", "abbr": "EPI", "color": (112, 48, 160)},
+    {"id": 3, "name": "Papillary dermis", "abbr": "PAP", "color": (0, 176, 240)},
+    {"id": 4, "name": "Reticular dermis", "abbr": "RET", "color": (127, 0, 255)},
+    {"id": 5, "name": "Hypodermis", "abbr": "HYP", "color": (192, 0, 0)},
+    {"id": 6, "name": "Glands", "abbr": "GLD", "color": (127, 96, 255)},
+    {"id": 7, "name": "Follicles", "abbr": "FOL", "color": (96, 96, 96)},
+    {"id": 8, "name": "Inflammation", "abbr": "INF", "color": (255, 56, 0)},
+    {"id": 9, "name": "Basal Cell Carcinoma", "abbr": "BCC", "color": (127, 255, 0)},
+    {"id": 10, "name": "Squamous Cell Carcinoma", "abbr": "SCC", "color": (255, 255, 0)},
+    {
+        "id": 11,
+        "name": "Intraepidermal Carcinoma",
+        "abbr": "IEC",
+        "color": (150, 150, 0),
+    },
+]
+
+
 def _ensure_output_dir(out_root: Path, image_path: Path) -> Path:
     out_dir = out_root / image_path.stem
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -64,7 +86,7 @@ def _load_image(path: Path) -> Image.Image:
 
 def _load_mask(path: Path) -> np.ndarray:
     mask = Image.open(path)
-    return np.array(mask)
+    return np.array(mask.convert("RGB"))
 
 
 def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
@@ -75,16 +97,25 @@ def _compute_max_margin(patch_size: int, scales: Sequence[float]) -> int:
     return max(1, margin)
 
 
-def _sample_centers(mask: np.ndarray, count: int, margin: int, positive: bool) -> List[Tuple[int, int]]:
+def _build_label_map(mask_rgb: np.ndarray) -> np.ndarray:
+    mask_rgb = mask_rgb[..., :3]
+    if mask_rgb.ndim == 2:
+        mask_rgb = np.repeat(mask_rgb[..., None], 3, axis=-1)
+    label_map = np.full(mask_rgb.shape[:2], -1, dtype=np.int16)
+    for class_info in CLASS_INFO:
+        color = np.asarray(class_info["color"], dtype=mask_rgb.dtype)
+        matches = np.all(mask_rgb == color, axis=-1)
+        label_map[matches] = class_info["id"]
+    return label_map
+
+
+def _sample_centers(label_map: np.ndarray, count: int, margin: int, class_id: int) -> List[Tuple[int, int]]:
     if count <= 0:
         return []
-    mask_binary = mask
-    if mask.ndim == 3:
-        mask_binary = mask.any(axis=-1)
-    coords = np.argwhere(mask_binary > 0) if positive else np.argwhere(mask_binary == 0)
+    coords = np.argwhere(label_map == class_id)
     if len(coords) == 0:
         return []
-    height, width = mask.shape[:2]
+    height, width = label_map.shape
     valid = [
         (int(x), int(y))
         for y, x in coords
@@ -246,80 +277,89 @@ def sample_image(
     random.seed(seed)
 
     image = _load_image(image_path)
-    mask = _load_mask(mask_path)
-    if mask.shape[:2] != (image.height, image.width):
+    mask_rgb = _load_mask(mask_path)
+    if mask_rgb.shape[:2] != (image.height, image.width):
         raise ValueError(
             f"Mask {mask_path} does not match image dimensions for {image_path.name}: "
-            f"expected {(image.height, image.width)}, got {mask.shape[:2]}"
+            f"expected {(image.height, image.width)}, got {mask_rgb.shape[:2]}"
         )
+    label_map = _build_label_map(mask_rgb)
 
     out_dir = _ensure_output_dir(out_root, image_path)
     margin = _compute_max_margin(patch_size, scales)
-    positive_centers = _sample_centers(mask, positive_bags, margin, positive=True)
-    negative_centers = _sample_centers(mask, negative_bags, margin, positive=False)
 
     bags: List[Dict[str, object]] = []
     patch_rows: List[Dict[str, str]] = []
     patient_id = _generate_patient_id(image_path)
-    label_pos_id, label_pos_name = label_encoder.encode("Positive")
-    label_neg_id, label_neg_name = label_encoder.encode("Negative")
+    class_lookup = {info["id"]: info for info in CLASS_INFO}
+    background_id = CLASS_INFO[0]["id"]
 
     bag_index = 0
-    for center_x, center_y in positive_centers:
-        prefix = f"patch_{bag_index}"
-        bag = generate_hierarchy_from_image(
-            image,
-            center_x,
-            center_y,
-            list(scales),
-            prefix,
-            out_dir,
-            patch_size,
-            tissue_threshold,
-            background_threshold,
-        )
-        if not bag:
+    for class_info in CLASS_INFO:
+        if class_info["id"] == background_id:
             continue
-        bag.node.update({"label": label_pos_name, "label_id": label_pos_id, "center": [center_x, center_y]})
-        bags.append(bag.node)
-        _record_patch_rows(
-            patch_rows,
-            bag.tiles,
-            patient_id,
-            image_path,
-            bag_index,
-            label_pos_name,
-            label_pos_id,
-        )
-        bag_index += 1
+        centers = _sample_centers(label_map, positive_bags, margin, class_info["id"])
+        if not centers:
+            continue
+        label_id, label_name = label_encoder.encode(class_info["name"])
+        for center_x, center_y in centers:
+            prefix = f"patch_{bag_index}"
+            bag = generate_hierarchy_from_image(
+                image,
+                center_x,
+                center_y,
+                list(scales),
+                prefix,
+                out_dir,
+                patch_size,
+                tissue_threshold,
+                background_threshold,
+            )
+            if not bag:
+                continue
+            bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+            bags.append(bag.node)
+            _record_patch_rows(
+                patch_rows,
+                bag.tiles,
+                patient_id,
+                image_path,
+                bag_index,
+                label_name,
+                label_id,
+            )
+            bag_index += 1
 
-    for center_x, center_y in negative_centers:
-        prefix = f"patch_{bag_index}"
-        bag = generate_hierarchy_from_image(
-            image,
-            center_x,
-            center_y,
-            list(scales),
-            prefix,
-            out_dir,
-            patch_size,
-            tissue_threshold,
-            background_threshold,
-        )
-        if not bag:
-            continue
-        bag.node.update({"label": label_neg_name, "label_id": label_neg_id, "center": [center_x, center_y]})
-        bags.append(bag.node)
-        _record_patch_rows(
-            patch_rows,
-            bag.tiles,
-            patient_id,
-            image_path,
-            bag_index,
-            label_neg_name,
-            label_neg_id,
-        )
-        bag_index += 1
+    centers_background = _sample_centers(label_map, negative_bags, margin, background_id)
+    if centers_background:
+        label_id, label_name = label_encoder.encode(class_lookup[background_id]["name"])
+        for center_x, center_y in centers_background:
+            prefix = f"patch_{bag_index}"
+            bag = generate_hierarchy_from_image(
+                image,
+                center_x,
+                center_y,
+                list(scales),
+                prefix,
+                out_dir,
+                patch_size,
+                tissue_threshold,
+                background_threshold,
+            )
+            if not bag:
+                continue
+            bag.node.update({"label": label_name, "label_id": label_id, "center": [center_x, center_y]})
+            bags.append(bag.node)
+            _record_patch_rows(
+                patch_rows,
+                bag.tiles,
+                patient_id,
+                image_path,
+                bag_index,
+                label_name,
+                label_id,
+            )
+            bag_index += 1
 
     bags_path = out_dir / "bags.json"
     with bags_path.open("w", encoding="utf-8") as f:
@@ -373,8 +413,15 @@ def parse_args() -> argparse.Namespace:
         help="Root directory containing masks that share the same filename stem as images",
     )
     parser.add_argument("output_dir", type=Path, help="Directory where patches and manifests are written")
-    parser.add_argument("--positive-bags", type=int, default=5, help="Number of positive bags to sample per image")
-    parser.add_argument("--negative-bags", type=int, default=5, help="Number of negative bags to sample per image")
+    parser.add_argument(
+        "--positive-bags",
+        type=int,
+        default=5,
+        help="Number of bags to sample per annotated class (excluding background)",
+    )
+    parser.add_argument(
+        "--negative-bags", type=int, default=5, help="Number of background bags to sample per image"
+    )
     parser.add_argument(
         "--magnifications",
         type=float,
@@ -419,7 +466,7 @@ def main() -> None:
         raise SystemExit(f"No images found under {args.image_dir} with extensions {args.image_exts}")
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
-    label_encoder = ValueLabelEncoder({"positive": (1, "Positive"), "negative": (0, "Negative")})
+    label_encoder = ValueLabelEncoder({info["name"].lower(): (info["id"], info["name"]) for info in CLASS_INFO})
 
     all_rows: List[Dict[str, str]] = []
     for index, image_path in enumerate(images):

--- a/scripts/sample_mask_multiscale_patches.py
+++ b/scripts/sample_mask_multiscale_patches.py
@@ -148,11 +148,13 @@ def generate_hierarchy_from_image(
     base_scale = float(scales[0])
     parent: Optional[Dict[str, object]] = None
 
+    mag_map = {2.0: "5x", 1.0: "10x", 0.5: "20x", 0.25: "40x"}
+
     for scale in scales:
         if scale <= 0:
             raise ValueError("Scale values must be positive")
         window_factor = scale / base_scale
-        suffix = f"{scale:.2f}mpp"
+        suffix = mag_map.get(scale, f"{scale:.2f}mpp")
         patch_id = f"{prefix}_{suffix}"
         out_path = out_dir / f"{patch_id}.png"
 
@@ -195,6 +197,7 @@ def generate_hierarchy_from_image(
 def _record_patch_rows(
     rows: List[Dict[str, str]],
     tiles: Iterable[PatchTile],
+    patient_id: str,
     image_path: Path,
     bag_index: int,
     label_name: str,
@@ -203,8 +206,12 @@ def _record_patch_rows(
     for tile in tiles:
         rows.append(
             {
-                "image_file": image_path.name,
-                "image_stem": image_path.stem,
+                "patient_id": patient_id,
+                "pathology_id": image_path.name,
+                "subtype": label_name,
+                "labels": str(label_id),
+                "resolved_path": str(image_path),
+                "slide_stem": image_path.stem,
                 "bag_index": str(bag_index),
                 "bag_label": label_name,
                 "bag_label_id": str(label_id),
@@ -214,6 +221,13 @@ def _record_patch_rows(
                 "patch_scale": tile.scale_suffix,
             }
         )
+
+
+def _generate_patient_id(image_path: Path) -> str:
+    """Return a deterministic pseudo-random identifier for ``image_path``."""
+
+    seed = abs(hash(image_path.stem.lower())) % 10**12
+    return f"{seed:012d}"
 
 
 def sample_image(
@@ -246,6 +260,7 @@ def sample_image(
 
     bags: List[Dict[str, object]] = []
     patch_rows: List[Dict[str, str]] = []
+    patient_id = _generate_patient_id(image_path)
     label_pos_id, label_pos_name = label_encoder.encode("Positive")
     label_neg_id, label_neg_name = label_encoder.encode("Negative")
 
@@ -267,7 +282,15 @@ def sample_image(
             continue
         bag.node.update({"label": label_pos_name, "label_id": label_pos_id, "center": [center_x, center_y]})
         bags.append(bag.node)
-        _record_patch_rows(patch_rows, bag.tiles, image_path, bag_index, label_pos_name, label_pos_id)
+        _record_patch_rows(
+            patch_rows,
+            bag.tiles,
+            patient_id,
+            image_path,
+            bag_index,
+            label_pos_name,
+            label_pos_id,
+        )
         bag_index += 1
 
     for center_x, center_y in negative_centers:
@@ -287,7 +310,15 @@ def sample_image(
             continue
         bag.node.update({"label": label_neg_name, "label_id": label_neg_id, "center": [center_x, center_y]})
         bags.append(bag.node)
-        _record_patch_rows(patch_rows, bag.tiles, image_path, bag_index, label_neg_name, label_neg_id)
+        _record_patch_rows(
+            patch_rows,
+            bag.tiles,
+            patient_id,
+            image_path,
+            bag_index,
+            label_neg_name,
+            label_neg_id,
+        )
         bag_index += 1
 
     bags_path = out_dir / "bags.json"
@@ -308,9 +339,16 @@ def _gather_images(image_root: Path, image_exts: Sequence[str]) -> List[Path]:
 
 
 def _write_manifest(path: Path, rows: Iterable[Dict[str, str]]) -> None:
+    rows = list(rows)
+    if not rows:
+        return
     fieldnames = [
-        "image_file",
-        "image_stem",
+        "patient_id",
+        "pathology_id",
+        "subtype",
+        "labels",
+        "resolved_path",
+        "slide_stem",
         "bag_index",
         "bag_label",
         "bag_label_id",


### PR DESCRIPTION
## Summary
- add a CLI script to sample multiscale patch hierarchies from paired image/mask datasets
- support configurable magnification chains, positive/negative bag counts, and manifest export

## Testing
- python -m py_compile scripts/sample_mask_multiscale_patches.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69316b13843c8327acd36debac7b7382)